### PR TITLE
Улучшение статистики для студентов

### DIFF
--- a/HwProj.Common/HwProj.Models/CoursesService/HomeworkTags.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/HomeworkTags.cs
@@ -1,0 +1,9 @@
+﻿namespace HwProj.Models.CoursesService
+{
+    public static class HomeworkTags
+    {
+        public const string Test = "Контрольная работа";
+        public const string BonusTask = "Доп. баллы";
+        public const string GroupWork = "Командная работа";
+    }
+}

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -14,6 +14,7 @@ using HwProj.Models.AuthService.DTO;
 using HwProj.Models.CoursesService.DTO;
 using Microsoft.EntityFrameworkCore;
 using HwProj.CoursesService.API.Domains;
+using HwProj.Models.CoursesService;
 using HwProj.Models.Roles;
 
 namespace HwProj.CoursesService.API.Controllers
@@ -201,7 +202,7 @@ namespace HwProj.CoursesService.API.Controllers
                 .Where(t => !string.IsNullOrEmpty(t))
                 .ToArray();
 
-            var defaultTags = new[] { HomeworkTags.Test, "Доп. баллы", "Командная работа" };
+            var defaultTags = new[] { HomeworkTags.Test, HomeworkTags.BonusTask, HomeworkTags.GroupWork };
             result = result.Concat(defaultTags).Distinct().ToArray();
 
             return Ok(result);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -3,6 +3,7 @@ using HwProj.CoursesService.API.Models;
 using HwProj.Models.CoursesService.ViewModels;
 using System;
 using System.Collections.Generic;
+using HwProj.Models.CoursesService;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace HwProj.CoursesService.API.Domains
@@ -22,7 +23,7 @@ namespace HwProj.CoursesService.API.Domains
                 IsDeadlineStrict = homework.IsDeadlineStrict,
                 PublicationDate = homework.PublicationDate,
                 CourseId = homework.CourseId,
-                IsGroupWork = tags.Contains("Командная работа"),
+                IsGroupWork = tags.Contains(HomeworkTags.GroupWork),
                 IsDeferred = DateTime.UtcNow < homework.PublicationDate,
                 Tasks = homework.Tasks.Select(t => t.ToHomeworkTaskViewModel()).ToList(),
                 Tags = tags.ToList(),
@@ -43,7 +44,7 @@ namespace HwProj.CoursesService.API.Domains
                 IsDeadlineStrict = task.IsDeadlineStrict,
                 PublicationDate = task.PublicationDate,
                 IsDeferred = DateTime.UtcNow < task.PublicationDate,
-                IsGroupWork = tags.Contains("Командная работа"),
+                IsGroupWork = tags.Contains(HomeworkTags.GroupWork),
                 HomeworkId = task.HomeworkId,
                 Tags = tags,
             };

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Filters/CourseDataFilterAttribute.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Filters/CourseDataFilterAttribute.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using HwProj.CoursesService.API.Models;
 using HwProj.Models;
+using HwProj.Models.CoursesService;
 using HwProj.Models.CoursesService.ViewModels;
 using HwProj.Utils.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/Homework.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/Homework.cs
@@ -26,9 +26,4 @@ namespace HwProj.CoursesService.API.Models
 
         public List<HomeworkTask> Tasks { get; set; }
     }
-
-    public static class HomeworkTags
-    {
-        public const string Test = "Контрольная работа";
-    }
 }

--- a/HwProj.SolutionsService/HwProj.SolutionsService.API/Controllers/SolutionsController.cs
+++ b/HwProj.SolutionsService/HwProj.SolutionsService.API/Controllers/SolutionsController.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using AutoMapper;
 using HwProj.CoursesService.Client;
+using HwProj.Models.CoursesService;
 using HwProj.Models.SolutionsService;
 using HwProj.Models.StatisticsService;
 using HwProj.SolutionsService.API.Domains;
@@ -243,7 +244,7 @@ namespace HwProj.SolutionsService.API.Controllers
             
             var bestStudentSolutions = course.Homeworks
                 .SelectMany(e => e.Tasks)
-                .Where(e => !e.Tags.Contains("Доп. баллы"))
+                .Where(e => !e.Tags.Contains(HomeworkTags.BonusTask))
                 .Select(task => new StatisticsCourseMeasureSolutionModel
                 {
                     TaskId = task.Id,

--- a/HwProj.SolutionsService/HwProj.SolutionsService.API/Controllers/SolutionsController.cs
+++ b/HwProj.SolutionsService/HwProj.SolutionsService.API/Controllers/SolutionsController.cs
@@ -243,6 +243,7 @@ namespace HwProj.SolutionsService.API.Controllers
             
             var bestStudentSolutions = course.Homeworks
                 .SelectMany(e => e.Tasks)
+                .Where(e => !e.Tags.Contains("Доп. баллы"))
                 .Select(task => new StatisticsCourseMeasureSolutionModel
                 {
                     TaskId = task.Id,

--- a/hwproj.front/src/components/Courses/Statistics/StudentCheckboxList.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentCheckboxList.tsx
@@ -31,7 +31,7 @@ const StudentCheckboxList: React.FC<StudentStatsListProps> = (props) => {
                     label='Выбрать студентов'
                 />
             )}
-            noOptionsText={'На курсе еще нет студентов'}
+            noOptionsText={'Нет студентов для выбора'}
             value={props.mates.filter(m => checked.includes(m.id))}
             onChange={(_, values) => {
                 const selectedStudentsId = values.map(v => v.id);

--- a/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
@@ -191,7 +191,7 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
             ...deadlineDates,
             ...straightAStudentLine.map(p => p.date),
             ...averageStudentLine.map(p => p.date),
-            ...studentChartsArray.flat().map(p => p.date)]
+            ...studentChartsArray.flat().map(p => p.date)].filter(d => d < Date.now())
     );
     const finishCourseDate = Array.from(characteristicDates).sort((x, y) => x - y).slice(-1)[0];
 
@@ -248,12 +248,11 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
                 />
                 <XAxis dataKey="date"
                        allowDuplicatedCategory={false}
-                       domain={Array.from(characteristicDates).sort((x, y) => x - y)
-                           .map(x => Utils.renderDateWithoutHours(new Date(x)))}
+                       domain={Array.from(characteristicDates).sort((x, y) => x - y)}
                        stroke={chartColors.axis}
                        strokeWidth={0.5}
-                       ticks={deadlineDateFormat.length != 0 ? deadlineDateFormat.map(x =>
-                           Utils.renderDateWithoutHours(new Date(x))) : ['']}
+                       ticks={deadlineDateFormat}
+                       tickFormatter={t => Utils.renderDateWithoutHours(new Date(t))}
                        tickLine={false}
                 />
                 <CartesianGrid vertical={false} strokeWidth={0.3}/>
@@ -271,12 +270,6 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
                 <Legend/>
                 {Array.from(studentCharts.entries()).map(([studentId, line]) => {
                     const studentName = fullNameById(studentId);
-                    const lineFormat  = line.map<IChartPointFormat>(x =>
-                        ({id: x.id,
-                            date: Utils.renderDateWithoutHours(new Date(x.date)),
-                            totalRatingValue : x.totalRatingValue,
-                            tasks : x.tasks})
-                    )
                     return <Line
                         onClick={_ => setHighlightStudent(studentName)}
                         activeDot={{
@@ -290,7 +283,7 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
                         strokeDasharray={studentName === straightAStudent || studentName === averageStudent ? '4' : '0'}
                         name={studentName}
                         dataKey="totalRatingValue"
-                        data={lineFormat}
+                        data={line}
                         isAnimationActive={false}
                         stroke={lineColors.get(studentName)}
                         strokeWidth={studentName === highlightStudent ? 5 : 3}

--- a/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
@@ -123,7 +123,6 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
 
     // для каждого студента отсортировали и сгруппировали задачи по дню последнего решения
     const studentTasks = new Map(solutions.map(cm => {
-        const studentId = cm.name + ' ' + cm.surname;
         const tasks = cm.homeworks!
             .filter(hw => hw.tasks && hw.tasks.length > 0)
             .flatMap(hw => hw.tasks!)
@@ -152,7 +151,7 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
         const groupedTasksToArray = Array.from(tasksGroupedByLastSolution.entries())
             .map(([_, tasks]) => tasks);
 
-        return [studentId, groupedTasksToArray];
+        return [cm.id!, groupedTasksToArray];
     }))
 
     const studentCharts = new Map([[straightAStudent, straightAStudentLine],
@@ -222,14 +221,20 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
         })
     }
 
+    const fullNameById = (id: string) => {
+        const student = solutions.find(solution => solution.id === id)
+        return student ? student.name + ' ' + student.surname : id;
+    }
+
     const deadlineDateFormat = [...deadlineDates, startCourseDate, finishCourseDate]
         .sort((x, y) => x - y).filter(item => item);
     const lineColors = useMemo(() => new Map<string, string>
     (Array.from(studentCharts.keys()).map(student => {
-        const color = student === straightAStudent ? '#2cba00' : (
-            student === averageStudent ? '#FFA756' : getRandomColorWithMinBrightness(student)
+        const studentName = fullNameById(student);
+        const color = studentName === straightAStudent ? '#2cba00' : (
+            studentName === averageStudent ? '#FFA756' : getRandomColorWithMinBrightness(studentName)
         );
-        return [student, color];
+        return [studentName, color];
     })), [props]);
 
     return (
@@ -264,7 +269,8 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
                         }}
                 />
                 <Legend/>
-                {Array.from(studentCharts.entries()).map(([studentName, line]) => {
+                {Array.from(studentCharts.entries()).map(([studentId, line]) => {
+                    const studentName = fullNameById(studentId);
                     const lineFormat  = line.map<IChartPointFormat>(x =>
                         ({id: x.id,
                             date: Utils.renderDateWithoutHours(new Date(x.date)),

--- a/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
@@ -9,7 +9,6 @@ import {
 } from "../../../api/";
 import StudentStatsTooltip, { ITaskChartView } from './StudentStatsTooltip';
 import Utils from "../../../services/Utils";
-import HomeworkTags from "../../Common/HomeworkTags"
 
 import {CartesianGrid, ComposedChart, Legend, Line, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import StudentStatsUtils from "../../../services/StudentStatsUtils";
@@ -66,8 +65,7 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
         return solutions.reduce<[number, IChartPoint[]]>(([total, points], solution, index) => {
             const totalRating = total + solution.rating!;
             const task = courseTasks.find(t => t.id === solution.taskId)!;
-            const isTest = task.tags!.includes(HomeworkTags.TestTag)
-            const taskView = {title: task.title!, maxRating: task.maxRating!, receiveRating: solution.rating!, isTest};
+            const taskView = {title: task.title!, maxRating: task.maxRating!, receiveRating: solution.rating!, tags: task.tags ?? []};
             const indexTasksWithSameDate = points.findIndex(p => p.date === publicationDates[index]);
 
             if (indexTasksWithSameDate === -1) {
@@ -157,10 +155,8 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
                     const lastSolution = task.solution!.filter(s => s.state != Solution.StateEnum.NUMBER_0).slice(-1)[0];
                     totalStudentRating += lastSolution.rating ? lastSolution.rating : 0;
                     const taskView = courseTasks.find(t => t.id === task.id)!;
-                    const isTest = taskView.tags!.includes(HomeworkTags.TestTag)
 
-
-                    return {title: taskView.title!, receiveRating: lastSolution.rating!, maxRating: taskView.maxRating!, isTest}
+                    return {title: taskView.title!, receiveRating: lastSolution.rating!, maxRating: taskView.maxRating!, tags: taskView.tags ?? []}
                 })
 
                 return {id: studentId, date : date.getTime(), totalRatingValue: totalStudentRating, tasks: tasksChartView};

--- a/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentProgressChart.tsx
@@ -7,8 +7,9 @@ import {
     StatisticsCourseMeasureSolutionModel,
     StatisticsCourseTasksModel
 } from "../../../api/";
-import StudentStatsTooltip from './StudentStatsTooltip';
+import StudentStatsTooltip, { ITaskChartView } from './StudentStatsTooltip';
 import Utils from "../../../services/Utils";
+import HomeworkTags from "../../Common/HomeworkTags"
 
 import {CartesianGrid, ComposedChart, Legend, Line, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import StudentStatsUtils from "../../../services/StudentStatsUtils";
@@ -22,22 +23,9 @@ interface IStudentProgressChartProps {
     averageStudentSolutions: StatisticsCourseMeasureSolutionModel[];
 }
 
-interface ITaskChartView {
-    title: string;
-    receiveRating?: number;
-    maxRating: number;
-}
-
 interface IChartPoint {
     id? : string;
     date : number;
-    totalRatingValue : number | null;
-    tasks : ITaskChartView[];
-}
-
-interface IChartPointFormat {
-    id? : string;
-    date : string;
     totalRatingValue : number | null;
     tasks : ITaskChartView[];
 }
@@ -78,7 +66,8 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
         return solutions.reduce<[number, IChartPoint[]]>(([total, points], solution, index) => {
             const totalRating = total + solution.rating!;
             const task = courseTasks.find(t => t.id === solution.taskId)!;
-            const taskView = {title: task.title!, maxRating: task.maxRating!, receiveRating: solution.rating!};
+            const isTest = task.tags!.includes(HomeworkTags.TestTag)
+            const taskView = {title: task.title!, maxRating: task.maxRating!, receiveRating: solution.rating!, isTest};
             const indexTasksWithSameDate = points.findIndex(p => p.date === publicationDates[index]);
 
             if (indexTasksWithSameDate === -1) {
@@ -168,8 +157,10 @@ const StudentProgressChart: React.FC<IStudentProgressChartProps> = (props) => {
                     const lastSolution = task.solution!.filter(s => s.state != Solution.StateEnum.NUMBER_0).slice(-1)[0];
                     totalStudentRating += lastSolution.rating ? lastSolution.rating : 0;
                     const taskView = courseTasks.find(t => t.id === task.id)!;
+                    const isTest = taskView.tags!.includes(HomeworkTags.TestTag)
 
-                    return {title: taskView.title!, receiveRating: lastSolution.rating!, maxRating: taskView.maxRating!}
+
+                    return {title: taskView.title!, receiveRating: lastSolution.rating!, maxRating: taskView.maxRating!, isTest}
                 })
 
                 return {id: studentId, date : date.getTime(), totalRatingValue: totalStudentRating, tasks: tasksChartView};

--- a/hwproj.front/src/components/Courses/Statistics/StudentPunctualityChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentPunctualityChart.tsx
@@ -56,6 +56,8 @@ const chartColors = {
 }
 const MAXIMUM_DEVIATION = 10;
 const MINIMUM_DEVIATION = 1 / 12;
+const EMPTY_SECTOR_LETTER_SIZE = 8;
+const BAR_LETTER_SIZE = 4;
 
 const CustomYAxisTick = (props : any) => {
     const { x, y, payload } = props;
@@ -73,7 +75,7 @@ const CustomXAxisTick = (props : ICustomXAxisProps) => {
     const { x, y, payload, sectors} = props;
     const [open, setOpen] = useState(false);
     const sector = sectors.get(payload.value)
-    const maxWordSize = MAXIMUM_DEVIATION + 4 * (sector?.barsAmount ?? 0)
+    const maxWordSize = EMPTY_SECTOR_LETTER_SIZE + BAR_LETTER_SIZE * (sector?.barsAmount ?? 0)
     const title = sector?.title ?? ""
     const customTitle = title.split(' ').slice(0, 3).map((word : string) =>
     {
@@ -147,6 +149,19 @@ const StudentPunctualityChart : React.FC<IStudentPunctualityChartProps> = (props
             window.open(data.link, '_blank');
         }
     }
+    const daysDifference = (firstDate: Date, secondDate : Date) => {
+        const msecInDay = 1000 * 3600 * 24;
+        return (new Date(firstDate).getTime() - new Date(secondDate).getTime()) / msecInDay;
+    }
+    const getDatesDiff = (solutionPublicationDate: Date, deadlineDate : Date) => {
+        const differenceInDays = daysDifference(deadlineDate, solutionPublicationDate);
+        return (
+            Math.abs(differenceInDays) > MAXIMUM_DEVIATION
+                ? MAXIMUM_DEVIATION * Math.sign(differenceInDays)
+                : (Math.abs(differenceInDays) < MINIMUM_DEVIATION
+                    ? MINIMUM_DEVIATION * Math.sign(differenceInDays)
+                    : differenceInDays));
+    }
     
     const homeworks = props.homeworks.filter(hw => hw.tasks && hw.tasks.length > 0);
     const tasks = [...new Set(homeworks.map(hw => hw.tasks!).flat())]
@@ -155,20 +170,6 @@ const StudentPunctualityChart : React.FC<IStudentPunctualityChartProps> = (props
             const [xDate, yDate] = [x.publicationDate!, y.publicationDate!];
             return xDate > yDate ? 1 : (yDate > xDate ? -1 : 0);
         })
-    
-    const daysDifference = (firstDate: Date, secondDate : Date) => {
-        const msecInDay = 1000 * 3600 * 24;
-        return (new Date(firstDate).getTime() - new Date(secondDate).getTime()) / msecInDay;
-    }
-    const getDatesDiff = (solutionPublicationDate: Date, deadlineDate : Date) => {
-        const differenceInDays = daysDifference(deadlineDate, solutionPublicationDate);
-        return ( 
-            Math.abs(differenceInDays) > MAXIMUM_DEVIATION 
-                ? MAXIMUM_DEVIATION * Math.sign(differenceInDays) 
-                : (Math.abs(differenceInDays) < MINIMUM_DEVIATION 
-                    ? MINIMUM_DEVIATION * Math.sign(differenceInDays) 
-                    : differenceInDays));
-    }
     
     const studentTaskSolutions = props.solutions.homeworks!.filter(hw => hw.tasks)
         .map(hw => hw.tasks!.filter(task => 

--- a/hwproj.front/src/components/Courses/Statistics/StudentPunctualityChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentPunctualityChart.tsx
@@ -40,6 +40,11 @@ interface ICustomTooltipProps {
     attemptRepresentation: Map<number, [IDatesDeviation, string, boolean]>;
 }
 
+interface ICustomXAxisProps {
+    [key: string]: any;
+    sectors: Map<number, ISectorProps>
+}
+
 type DeadlineRepresentation = Map<number, number>
 type SectorRepresentation = Map<number, [number, ISectorProps]>
 
@@ -64,11 +69,12 @@ const CustomYAxisTick = (props : any) => {
     )
 }
 
-const CustomXAxisTick = (props : any) => {
+const CustomXAxisTick = (props : ICustomXAxisProps) => {
     const { x, y, payload, sectors} = props;
     const [open, setOpen] = useState(false);
-    const maxWordSize = MAXIMUM_DEVIATION + 4 * sectors.get(payload.value)?.barsAmount
-    const title : string = sectors.get(payload.value)?.title ?? ""
+    const sector = sectors.get(payload.value)
+    const maxWordSize = MAXIMUM_DEVIATION + 4 * (sector?.barsAmount ?? 0)
+    const title = sector?.title ?? ""
     const customTitle = title.split(' ').slice(0, 3).map((word : string) =>
     {
         if (word.length > maxWordSize) {
@@ -96,7 +102,7 @@ const CustomXAxisTick = (props : any) => {
     )
 }
 
-const CustomTooltip : React.FC<ICustomTooltipProps> = (props) => {
+const CustomTooltip: React.FC<ICustomTooltipProps> = (props) => {
     const formatValueToText = () => {
         if (props.payload![0].name === 'scatter') {
             return 'День дедлайна'
@@ -175,7 +181,8 @@ const StudentPunctualityChart : React.FC<IStudentPunctualityChartProps> = (props
     
     const sectorRepresentation = studentTaskSolutions.reduce<[SectorRepresentation, number]>
     (([prevSectors, leftBorder], task, i) => {
-        const title = tasks.find(t => t.id === task.id)!.title!;
+        const taskView = tasks.find(t => t.id === task.id)!;
+        const title = taskView.title!;
         const sector = {title, barsAmount: props.sectorSizes[i]};
         prevSectors.set(task.id!, [leftBorder, sector])
         

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
@@ -12,7 +12,6 @@ import HelpPopoverChartInfo from './HelpPopoverChartInfo';
 import StudentCheckboxList from "./StudentCheckboxList";
 import StudentProgressChart from "./StudentProgressChart";
 import StudentPunctualityChart from './StudentPunctualityChart';
-import task from "../../Tasks/Task";
 
 interface IStudentStatsChartState {
     isFound: boolean;
@@ -196,7 +195,12 @@ const StudentStatsChart: React.FC = () => {
                 </Grid>
             </div>
         )
+    } else if (state.isFound && !tasksAmount) {
+        return <div className="container">
+            <p>На курсе нет задач</p>
+        </div>
     }
+    
     return <div className="container">
         <p>Загрузка...</p>
         <CircularProgress/>

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
@@ -38,12 +38,6 @@ const StudentStatsChart: React.FC = () => {
         averageStudent: []
     })
     const [sectorSizes, setSectorSizes] = useState<number[]>([]);
-    useEffect(() => {
-        const tasksWithDeadlineAmount = state.homeworks
-            .flatMap(h => h.tasks ?? []).filter(t => t.hasDeadline).length;
-        
-        setSectorSizes(new Array(tasksWithDeadlineAmount).fill(0));
-    }, [state]);
     const handleStudentSelection = (studentIds : string[]) => {
         const newSectorSizes = sectorSizes.map((_, i) => {
             const taskSectorSizes = studentIds.map(id => {
@@ -63,6 +57,12 @@ const StudentStatsChart: React.FC = () => {
     const setCurrentState = async () => {
         const params =
             await ApiSingleton.statisticsApi.apiStatisticsByCourseIdChartsGet(+courseId!);
+
+        if (params.studentStatistics && params.studentStatistics.length > 0) {
+            const sectorSizes = params.studentStatistics[0].homeworks!
+                .flatMap(h => h.tasks!.map(t => t.solution!.length))
+            setSectorSizes(sectorSizes)
+        }
 
         setState({
             isFound: true,

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
@@ -53,7 +53,6 @@ const StudentStatsChart: React.FC = () => {
         setSelectedStudents(studentIds);
     }
 
-
     const setCurrentState = async () => {
         const params =
             await ApiSingleton.statisticsApi.apiStatisticsByCourseIdChartsGet(+courseId!);

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
@@ -37,17 +37,17 @@ const StudentStatsChart: React.FC = () => {
         averageStudent: []
     })
     const [sectorSizes, setSectorSizes] = useState<number[]>([]);
-    const handleStudentSelection = (studentIds : string[]) => {
+    const handleStudentSelection = (studentIds: string[]) => {
         const newSectorSizes = sectorSizes.map((_, i) => {
             const taskSectorSizes = studentIds.map(id => {
                 const task = state.solutions.filter(s => s.id === id)[0]
                     .homeworks!.flatMap(h => h.tasks ?? [])[i]
                 return task.solution!.length;
             })
-            
+
             return Math.max(...taskSectorSizes);
         })
-        
+
         setSectorSizes(newSectorSizes);
         setSelectedStudents(studentIds);
     }
@@ -161,16 +161,16 @@ const StudentStatsChart: React.FC = () => {
                                 />
                             </Paper>
                         </Box>
-                        {selectedStudents.length > 0 && <Box mb={5}>
-                            <Typography variant="h6" align="center" color="textSecondary">
-                                Анализ соблюдения сроков выполнения задач
-                                <HelpPopoverChartInfo chartName='punctuality'/>
-                            </Typography>
-                        </Box>}
                     </Grid>
-                    {tasksWithDeadlineAmount > 0 
-                        ? selectedStudents.map((studentId, index) =>
-                            <Grid xs={12} item>
+                    {tasksWithDeadlineAmount > 0 && selectedStudents.length > 0 &&
+                        <Grid item xs={12}>
+                            <Box mb={5}>
+                                <Typography variant="h6" align="center" color="textSecondary">
+                                    Анализ соблюдения сроков выполнения задач
+                                    <HelpPopoverChartInfo chartName='punctuality'/>
+                                </Typography>
+                            </Box>
+                            {selectedStudents.map((studentId, index) =>
                                 <Box key={studentId} mb={3}>
                                     <Paper elevation={2} style={{padding: 15}}>
                                         <Typography variant="h6" style={{marginBottom: 7}} color="textSecondary">
@@ -185,13 +185,8 @@ const StudentStatsChart: React.FC = () => {
                                         />
                                     </Paper>
                                 </Box>
-                            </Grid>)
-                        
-                        :   <Grid xs={12} item>
-                                <Typography variant="subtitle1" color="textSecondary">
-                                    На курсе еще нет задач с дедлайнами.
-                                </Typography>
-                            </Grid>}
+                            )}
+                        </Grid>}
                 </Grid>
             </div>
         )
@@ -200,7 +195,7 @@ const StudentStatsChart: React.FC = () => {
             <p>На курсе нет задач</p>
         </div>
     }
-    
+
     return <div className="container">
         <p>Загрузка...</p>
         <CircularProgress/>

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
@@ -26,6 +26,7 @@ const StudentStatsTooltip : React.FC<ITooltipProps> = (props) => {
                     props.payload.map(item => {
                         if (item.payload.id! == props.activeId) {
                             const dateNumber = Date.parse(item.payload.date.split('.').reverse().join('/'));
+                            const tasks = item.payload.tasks;
                             return (
                                 <>
                                     <p style={{fontWeight: 'bold', textAlign: 'center', padding: 3, marginBottom: 0, backgroundColor: 'rgba(232, 232, 232, 0.8)'}}>
@@ -33,10 +34,12 @@ const StudentStatsTooltip : React.FC<ITooltipProps> = (props) => {
                                     </p>
                                     
                                     <p style={{margin: '3px 5px 2px 5px'}}>Баллов на текущий момент: <b>{item.value}</b></p>
-                                    <p style={{margin: '3px 5px 0px 5px'}}>Сданные в этот день задачи</p>
+                                    <p style={{margin: '3px 5px 0px 5px'}}>
+                                        {tasks.length ? "Сданные в этот день задачи" : "Нет сданных задач"}
+                                    </p>
                                     
                                     <List sx={{listStyleType: 'disc', pl: 3, pt: 0}}>
-                                        {item.payload.tasks.map((task : ITaskChartView) => (
+                                        {tasks.map((task : ITaskChartView) => (
                                             <ListItem sx={{display: 'list-item', padding: 0}}>
                                                 <p style={{marginTop: 2, marginBottom: 2, marginRight: 5}}>
                                                     {task.title} <b>{+task.receiveRating!.toFixed(2)}/{task.maxRating}</b>

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
@@ -25,12 +25,11 @@ const StudentStatsTooltip : React.FC<ITooltipProps> = (props) => {
                 {
                     props.payload.map(item => {
                         if (item.payload.id! == props.activeId) {
-                            const dateNumber = Date.parse(item.payload.date.split('.').reverse().join('/'));
                             const tasks = item.payload.tasks;
                             return (
                                 <>
                                     <p style={{fontWeight: 'bold', textAlign: 'center', padding: 3, marginBottom: 0, backgroundColor: 'rgba(232, 232, 232, 0.8)'}}>
-                                        {Utils.renderReadableDateWithoutTime(new Date(dateNumber))}
+                                        {Utils.renderReadableDateWithoutTime(new Date(item.payload.date))}
                                     </p>
                                     
                                     <p style={{margin: '3px 5px 2px 5px'}}>Баллов на текущий момент: <b>{item.value}</b></p>

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
@@ -4,12 +4,14 @@ import {
     Payload,
 } from 'recharts/types/component/DefaultTooltipContent';
 import {List, ListItem} from '@mui/material';
+import { TestTip } from "../../Common/HomeworkTags"
 import Utils from "../../../services/Utils";
 
-interface ITaskChartView {
+export interface ITaskChartView {
     title : string;
     receiveRating?: number;
     maxRating: number;
+    isTest: boolean;
 }
 
 interface ITooltipProps {
@@ -41,7 +43,7 @@ const StudentStatsTooltip : React.FC<ITooltipProps> = (props) => {
                                         {tasks.map((task : ITaskChartView) => (
                                             <ListItem sx={{display: 'list-item', padding: 0}}>
                                                 <p style={{marginTop: 2, marginBottom: 2, marginRight: 5}}>
-                                                    {task.title} <b>{+task.receiveRating!.toFixed(2)}/{task.maxRating}</b>
+                                                    {task.title}{task.isTest && <TestTip/>} <b>{+task.receiveRating!.toFixed(2)}/{task.maxRating}</b>
                                                 </p>
                                             </ListItem>
                                         ))}

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
@@ -4,8 +4,7 @@ import {
     Payload,
 } from 'recharts/types/component/DefaultTooltipContent';
 import {List, ListItem} from '@mui/material';
-import { TestTip, BonusTip } from "../../Common/HomeworkTags"
-import HomeworkTags from "../../Common/HomeworkTags"
+import { getTip } from "../../Common/HomeworkTags"
 import Utils from "../../../services/Utils";
 
 export interface ITaskChartView {
@@ -42,11 +41,9 @@ const StudentStatsTooltip : React.FC<ITooltipProps> = (props) => {
                                     
                                     <List sx={{listStyleType: 'disc', pl: 3, pt: 0}}>
                                         {tasks.map((task : ITaskChartView) => {
-                                            const isTest = task.tags.includes(HomeworkTags.TestTag);
-                                            const isBonus = task.tags.includes(HomeworkTags.BonusTag);
                                             return <ListItem sx={{display: 'list-item', padding: 0}}>
                                                 <p style={{marginTop: 2, marginBottom: 2, marginRight: 5}}>
-                                                    {task.title}{isTest && <TestTip/>}{isBonus && <BonusTip/>}{` `}
+                                                    {task.title}{getTip(task)}{` `}
                                                     <b>{+task.receiveRating!.toFixed(2)}/{task.maxRating}</b>
                                                 </p>
                                             </ListItem>

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsTooltip.tsx
@@ -4,14 +4,15 @@ import {
     Payload,
 } from 'recharts/types/component/DefaultTooltipContent';
 import {List, ListItem} from '@mui/material';
-import { TestTip } from "../../Common/HomeworkTags"
+import { TestTip, BonusTip } from "../../Common/HomeworkTags"
+import HomeworkTags from "../../Common/HomeworkTags"
 import Utils from "../../../services/Utils";
 
 export interface ITaskChartView {
     title : string;
     receiveRating?: number;
     maxRating: number;
-    isTest: boolean;
+    tags: string[];
 }
 
 interface ITooltipProps {
@@ -40,13 +41,16 @@ const StudentStatsTooltip : React.FC<ITooltipProps> = (props) => {
                                     </p>
                                     
                                     <List sx={{listStyleType: 'disc', pl: 3, pt: 0}}>
-                                        {tasks.map((task : ITaskChartView) => (
-                                            <ListItem sx={{display: 'list-item', padding: 0}}>
+                                        {tasks.map((task : ITaskChartView) => {
+                                            const isTest = task.tags.includes(HomeworkTags.TestTag);
+                                            const isBonus = task.tags.includes(HomeworkTags.BonusTag);
+                                            return <ListItem sx={{display: 'list-item', padding: 0}}>
                                                 <p style={{marginTop: 2, marginBottom: 2, marginRight: 5}}>
-                                                    {task.title}{task.isTest && <TestTip/>} <b>{+task.receiveRating!.toFixed(2)}/{task.maxRating}</b>
+                                                    {task.title}{isTest && <TestTip/>}{isBonus && <BonusTip/>}{` `}
+                                                    <b>{+task.receiveRating!.toFixed(2)}/{task.maxRating}</b>
                                                 </p>
                                             </ListItem>
-                                        ))}
+                                        })}
                                     </List>
                                 </>
                             )


### PR DESCRIPTION
Данный ПР содержит исправления и улучшения визуализации статистики студентов в виде графиков. Ниже будут перечислены основные из них:

- Проблема с рендерингом PunctualityChart при отсутствии дедлайнов у всех задач
Теперь при отсутствии дедлайнов у всех задач просто не показывается PunctualityChart
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/74eba4bc-8e6a-4e53-a138-0fba96dc2dc5)

- Выравнивание для PunctualityChart
При выборе нескольких студентов их сектора с задачами будут выравнены для удобства сравнения
<details>
<summary>скрин</summary>
  
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/68d41ebc-de75-4590-9585-1c153543553a)

</details>

- Незаметность некоторых свечек на графике из-за слишком маленького отклонения
Установлена минимальная высота для всех свечек, равная высоте для отклонения в 2ч
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/3984d70a-8593-4d3d-972f-58907b3d56dd)

- исправлен рендеринг дат для Safari

- При нажатии на свечку в PunctualityChart пользователь сможет перейти на страницу с решением

- Теперь у Круглого отличника не учитываются задачи, помеченные тегом "Доп. баллы"

- Добавлены индексы "тест" и "доп" для задач с соотв тегами
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/a6cfc264-7d6c-4847-9b2f-2d3d7abac283)

- добавлены даты для тултипов решений в PunctualityChart (аналогично дедлайнам)

- Сданные в этот день задачи: {empty list} =>
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/25c95422-5c13-42c2-9e3e-83684e56af2d)

- noOptionsText: “На курсе еще нет студентов” ⇒ “Нет студентов для выбора”
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/5e1224fa-8b83-46f8-b7c1-e394ce6045d8)

- Появление "ложного скролла" при вызове тултипа в PunctualityChart
Если вызывается тултип в правом углу чарта, то на мгновение появляется скролл бар, хотя фактическая ширина графика не менялась. Пробовал разные варианты, но тк тултип это csv так и не получилось по нормальному обойти проблему, поэтому теперь у каждого графика по умолчанию будет неактивный скролл бар
![image](https://github.com/InteIIigeNET/HwProj-2.0.1/assets/113193908/b55b5ec7-8486-4bf5-b735-0cedbce27e55)