### PR TITLE
Поддержка фильтров курсов для менторов

### DIFF
--- a/HwProj.APIGateway/HwProj.APIGateway.API/ApplicationProfile.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/ApplicationProfile.cs
@@ -2,6 +2,8 @@
 using HwProj.Models.AuthService.DTO;
 using HwProj.Models.AuthService.ViewModels;
 using HwProj.Models.CoursesService;
+using HwProj.Models.CoursesService.DTO;
+using HwProj.Models.CoursesService.ViewModels;
 
 namespace HwProj.APIGateway.API
 {
@@ -9,7 +11,8 @@ namespace HwProj.APIGateway.API
     {
         public ApplicationProfile()
         {
-            CreateMap<InviteExpertViewModel, CreateCourseFilterModel>();
+            CreateMap<InviteExpertViewModel, CreateCourseFilterDTO>();
+            CreateMap<WorkspaceViewModel, CreateCourseFilterDTO>();
         }
     }
 }

--- a/HwProj.APIGateway/HwProj.APIGateway.API/ApplicationProfile.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/ApplicationProfile.cs
@@ -12,7 +12,8 @@ namespace HwProj.APIGateway.API
         public ApplicationProfile()
         {
             CreateMap<InviteExpertViewModel, CreateCourseFilterDTO>();
-            CreateMap<WorkspaceViewModel, CreateCourseFilterDTO>();
+            CreateMap<WorkspaceDTO, CreateCourseFilterDTO>();
+            CreateMap<CourseFilterDTO, WorkspaceDTO>();
         }
     }
 }

--- a/HwProj.APIGateway/HwProj.APIGateway.API/ApplicationProfile.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/ApplicationProfile.cs
@@ -12,8 +12,7 @@ namespace HwProj.APIGateway.API
         public ApplicationProfile()
         {
             CreateMap<InviteExpertViewModel, CreateCourseFilterDTO>();
-            CreateMap<WorkspaceDTO, CreateCourseFilterDTO>();
-            CreateMap<CourseFilterDTO, WorkspaceDTO>();
+            CreateMap<EditMentorWorkspaceDTO, CreateCourseFilterDTO>();
         }
     }
 }

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -175,25 +175,25 @@ namespace HwProj.APIGateway.API.Controllers
 
         [HttpPost("editMentorWorkspace/{courseId}/{mentorId}")]
         [Authorize(Roles = Roles.LecturerRole)]
-        [ProducesResponseType(typeof(Result), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> EditMentorWorkspace(
-            long courseId, string mentorId, WorkspaceViewModel workspaceViewModel)
+            long courseId, string mentorId, WorkspaceDTO workspaceDto)
         {
             var mentor = await AuthServiceClient.GetAccountData(mentorId);
             if (mentor == null)
                 return NotFound("Пользователь с такой почтой не найден");
 
-            if (mentor.Role != Roles.LecturerOrExpertRole)
+            if (!Roles.LecturerOrExpertRole.Contains(mentor.Role))
                 return BadRequest("Пользователь с такой почтой не является преподавателем или экспертом");
 
             var courseFilterModel = _mapper.Map<CreateCourseFilterDTO>(workspaceViewModel);
             courseFilterModel.UserId = mentorId;
 
-            var courseFilterCreationResult = await _coursesClient.CreateOrUpdateCourseFilter(courseId, courseFilterModel);
+            var courseFilterCreationResult =
+                await _coursesClient.CreateOrUpdateCourseFilter(courseId, courseFilterModel);
 
             return courseFilterCreationResult.Succeeded
                 ? Ok() as IActionResult
-                : BadRequest(courseFilterCreationResult.Errors);
+                : BadRequest(courseFilterCreationResult.Errors[0]);
         }
     }
 }

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -9,6 +9,7 @@ using HwProj.CoursesService.Client;
 using HwProj.Models.AuthService.DTO;
 using HwProj.Models.CoursesService.DTO;
 using HwProj.Models.CoursesService.ViewModels;
+using HwProj.Models.Result;
 using HwProj.Models.Roles;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -174,6 +175,7 @@ namespace HwProj.APIGateway.API.Controllers
 
         [HttpPost("editMentorWorkspace/{courseId}/{mentorId}")]
         [Authorize(Roles = Roles.LecturerRole)]
+        [ProducesResponseType(typeof(Result), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> EditMentorWorkspace(
             long courseId, string mentorId, WorkspaceViewModel workspaceViewModel)
         {

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/ExpertsController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/ExpertsController.cs
@@ -5,7 +5,7 @@ using HwProj.AuthService.Client;
 using HwProj.CoursesService.Client;
 using HwProj.Models.AuthService.DTO;
 using HwProj.Models.AuthService.ViewModels;
-using HwProj.Models.CoursesService;
+using HwProj.Models.CoursesService.DTO;
 using HwProj.Models.Result;
 using HwProj.Models.Roles;
 using Microsoft.AspNetCore.Authorization;
@@ -43,9 +43,10 @@ namespace HwProj.APIGateway.API.Controllers
             if (inviteExpertView.UserId != expert.UserId)
                 return BadRequest("Идентификатор эксперта с такой почтой не соответствует переданному идентификатору");
 
-            var courseFilterModel = _mapper.Map<CreateCourseFilterModel>(inviteExpertView);
+            var courseFilterDto = _mapper.Map<CreateCourseFilterDTO>(inviteExpertView);
 
-            var courseFilterCreationResult = await _coursesClient.CreateOrUpdateExpertCourseFilter(courseFilterModel);
+            var courseFilterCreationResult =
+                await _coursesClient.CreateOrUpdateCourseFilter(inviteExpertView.CourseId, courseFilterDto);
             if (!courseFilterCreationResult.Succeeded) return BadRequest(courseFilterCreationResult.Errors);
 
             var acceptanceResult = await _coursesClient.AcceptLecturer(inviteExpertView.CourseId,

--- a/HwProj.Common/HwProj.Models/AuthService/ViewModels/InviteExpertViewModel.cs
+++ b/HwProj.Common/HwProj.Models/AuthService/ViewModels/InviteExpertViewModel.cs
@@ -13,7 +13,5 @@ namespace HwProj.Models.AuthService.ViewModels
         public List<string> StudentIds { get; set; } = new List<string>();
 
         public List<long> HomeworkIds { get; set; } = new List<long>();
-
-        public List<string> MentorIds { get; set; } = new List<string>();
     }
 }

--- a/HwProj.Common/HwProj.Models/CoursesService/DTO/CourseFilterDTO.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/DTO/CourseFilterDTO.cs
@@ -1,14 +1,13 @@
 ﻿using System.Collections.Generic;
 
-namespace HwProj.Models.CoursesService.ViewModels
+namespace HwProj.Models.CoursesService.DTO
 {
-    public class WorkspaceViewModel
+    public class CourseFilterDTO
     {
         public List<string> StudentIds { get; set; } = new List<string>();
 
         public List<long> HomeworkIds { get; set; } = new List<long>();
 
         public List<string> MentorIds { get; set; } = new List<string>();
-
     }
 }

--- a/HwProj.Common/HwProj.Models/CoursesService/DTO/CreateCourseFilterDTO.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/DTO/CreateCourseFilterDTO.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace HwProj.Models.CoursesService.DTO
+{
+    public class CreateCourseFilterDTO
+    {
+        public string UserId { get; set; }
+
+        public List<string> StudentIds { get; set; } = new List<string>();
+
+        public List<long> HomeworkIds { get; set; } = new List<long>();
+
+        public List<string> MentorIds { get; set; } = new List<string>();
+    }
+}

--- a/HwProj.Common/HwProj.Models/CoursesService/DTO/EditMentorWorkspaceDTO.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/DTO/EditMentorWorkspaceDTO.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace HwProj.Models.CoursesService.ViewModels
+namespace HwProj.Models.CoursesService.DTO
 {
-    public class WorkspaceDTO
+    public class EditMentorWorkspaceDTO
     {
         public List<string> StudentIds { get; set; } = new List<string>();
 

--- a/HwProj.Common/HwProj.Models/CoursesService/DTO/WorkspaceDTO.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/DTO/WorkspaceDTO.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace HwProj.Models.CoursesService.ViewModels
+{
+    public class WorkspaceDTO
+    {
+        public List<string> StudentIds { get; set; } = new List<string>();
+
+        public List<long> HomeworkIds { get; set; } = new List<long>();
+    }
+}

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/WorkspaceViewModel.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/WorkspaceViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace HwProj.Models.CoursesService.ViewModels
+{
+    public class WorkspaceViewModel
+    {
+        public List<string> StudentIds { get; set; } = new List<string>();
+
+        public List<long> HomeworkIds { get; set; } = new List<long>();
+
+        public List<string> MentorIds { get; set; } = new List<string>();
+
+    }
+}

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/WorkspaceViewModel.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/WorkspaceViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using HwProj.Models.AuthService.DTO;
+
+namespace HwProj.Models.CoursesService.ViewModels
+{
+    public class WorkspaceViewModel
+    {
+        public AccountDataDto[] Students { get; set; }
+
+        public HomeworkViewModel[] Homeworks { get; set; }
+    }
+}

--- a/HwProj.CoursesService/HwProj.CoursesService.API/ApplicationProfile.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/ApplicationProfile.cs
@@ -20,6 +20,7 @@ namespace HwProj.CoursesService.API
             CreateMap<CreateTaskViewModel, HomeworkTask>().ReverseMap();
             
             CreateMap<CreateCourseFilterDTO, CreateCourseFilterModel>();
+            CreateMap<Filter, CourseFilterDTO>();
         }
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/ApplicationProfile.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/ApplicationProfile.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
 using HwProj.CoursesService.API.Models;
+using HwProj.Models.CoursesService;
+using HwProj.Models.CoursesService.DTO;
 using HwProj.Models.CoursesService.ViewModels;
 
 namespace HwProj.CoursesService.API
@@ -16,6 +18,8 @@ namespace HwProj.CoursesService.API
             CreateMap<CreateHomeworkViewModel, Homework>();
             CreateMap<HomeworkTask, HomeworkTaskViewModel>().ReverseMap();
             CreateMap<CreateTaskViewModel, HomeworkTask>().ReverseMap();
+            
+            CreateMap<CreateCourseFilterDTO, CreateCourseFilterModel>();
         }
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
@@ -34,6 +34,16 @@ namespace HwProj.CoursesService.API.Controllers
 
             var result = await _courseFilterService.CreateOrUpdateCourseFilter(courseFilterModel);
             return Ok(result);
+
+        [HttpGet("get/{courseId}/{userId}")]
+        [ProducesResponseType(typeof(CourseFilterDTO), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> Get(long courseId, string userId)
+        {
+            var result = await _courseFilterService.Get(courseId, userId);
+
+            return result.Succeeded
+                ? Ok(result.Value) as IActionResult
+                : NotFound(result.Errors[0]);
         }
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
@@ -37,16 +37,5 @@ namespace HwProj.CoursesService.API.Controllers
                 ? Ok(result.Value) as IActionResult
                 : BadRequest(result.Errors[0]);
         }
-
-        [HttpGet("get/{courseId}/{userId}")]
-        [ProducesResponseType(typeof(CourseFilterDTO), (int)HttpStatusCode.OK)]
-        public async Task<IActionResult> Get(long courseId, string userId)
-        {
-            var result = await _courseFilterService.Get(courseId, userId);
-
-            return result.Succeeded
-                ? Ok(result.Value) as IActionResult
-                : NotFound(result.Errors[0]);
-        }
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
@@ -33,7 +33,10 @@ namespace HwProj.CoursesService.API.Controllers
             courseFilterModel.CourseId = courseId;
 
             var result = await _courseFilterService.CreateOrUpdateCourseFilter(courseFilterModel);
-            return Ok(result);
+            return result.Succeeded
+                ? Ok(result.Value) as IActionResult
+                : BadRequest(result.Errors[0]);
+        }
 
         [HttpGet("get/{courseId}/{userId}")]
         [ProducesResponseType(typeof(CourseFilterDTO), (int)HttpStatusCode.OK)]

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CourseFiltersController.cs
@@ -1,6 +1,10 @@
+using System.Net;
 using System.Threading.Tasks;
+using AutoMapper;
+using HwProj.CoursesService.API.Filters;
 using HwProj.CoursesService.API.Services;
 using HwProj.Models.CoursesService;
+using HwProj.Models.CoursesService.DTO;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HwProj.CoursesService.API.Controllers
@@ -10,16 +14,25 @@ namespace HwProj.CoursesService.API.Controllers
     public class CourseFiltersController : Controller
     {
         private readonly ICourseFilterService _courseFilterService;
+        private readonly IMapper _mapper;
 
-        public CourseFiltersController(ICourseFilterService courseFilterService)
+        public CourseFiltersController(
+            ICourseFilterService courseFilterService,
+            IMapper mapper)
         {
             _courseFilterService = courseFilterService;
+            _mapper = mapper;
         }
 
-        [HttpPost("createExpertFilter")]
-        public async Task<IActionResult> CreateCourseFilter([FromBody] CreateCourseFilterModel courseFilterModel)
+        [HttpPost("{courseId}/create")]
+        [ServiceFilter(typeof(CourseMentorOnlyAttribute))]
+        [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> Create(long courseId, [FromBody] CreateCourseFilterDTO courseFilterDto)
         {
-            var result = await _courseFilterService.CreateOrUpdateExpertFilter(courseFilterModel);
+            var courseFilterModel = _mapper.Map<CreateCourseFilterModel>(courseFilterDto);
+            courseFilterModel.CourseId = courseId;
+
+            var result = await _courseFilterService.CreateOrUpdateCourseFilter(courseFilterModel);
             return Ok(result);
         }
     }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -55,6 +55,16 @@ namespace HwProj.CoursesService.API.Controllers
             return Ok(course);
         }
 
+        [HttpGet("getForMentor/{courseId}/{mentorId}")]
+        [ServiceFilter(typeof(CourseMentorOnlyAttribute))]
+        public async Task<IActionResult> GetForMentor(long courseId, string mentorId)
+        {
+            var course = await _coursesService.GetAsync(courseId, mentorId);
+            if (course == null) return NotFound();
+
+            return Ok(course);
+        }
+
         [CourseDataFilter]
         [HttpGet("getByTask/{taskId}")]
         public async Task<IActionResult> GetByTask(long taskId)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/Filter.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/Filter.cs
@@ -7,11 +7,11 @@ namespace HwProj.CoursesService.API.Models
     {
         [JsonProperty(PropertyName = "STUD")] 
         public List<string> StudentIds { get; set; }
-        
+
         [JsonProperty(PropertyName = "HMW")] 
         public List<long> HomeworkIds { get; set; }
         
         [JsonProperty(PropertyName = "MENT")]
         public List<string> MentorIds { get; set; }
     }
-}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+}

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
@@ -18,7 +18,7 @@ namespace HwProj.CoursesService.API.Services
             _courseFilterRepository = courseFilterRepository;
         }
         
-        public async Task<Result<long>> CreateOrUpdateExpertFilter(CreateCourseFilterModel courseFilterModel)
+        public async Task<Result<long>> CreateOrUpdateCourseFilter(CreateCourseFilterModel courseFilterModel)
         {
             var areViewInvalid = courseFilterModel.IsFilterParametersEmpty();
             if (areViewInvalid)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
@@ -28,7 +28,7 @@ namespace HwProj.CoursesService.API.Services
             var areViewInvalid = courseFilterModel.IsFilterParametersEmpty();
             if (areViewInvalid)
             {
-                return Result<long>.Failed("Необходимо выделить эксперту хотя бы одного студента и домашнюю работу");
+                return Result<long>.Failed("Необходимо выделить ментору хотя бы одного студента и домашнюю работу");
             }
 
             var filter = CourseFilterUtils.CreateFilter(courseFilterModel);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
@@ -49,19 +49,6 @@ namespace HwProj.CoursesService.API.Services
             return Result<long>.Success(filterId);
         }
 
-        public async Task<Result<CourseFilterDTO>> Get(long courseId, string userId)
-        {
-            var courseFilter = await _courseFilterRepository.GetAsync(userId, courseId);
-            if (courseFilter?.Filter == null)
-            {
-                return Result<CourseFilterDTO>.Failed();
-            }
-
-            var courseFilterDto = _mapper.Map<CourseFilterDTO>(courseFilter.Filter);
-
-            return Result<CourseFilterDTO>.Success(courseFilterDto);
-        }
-
         public async Task UpdateAsync(long courseFilterId, Filter filter)
         {
             var courseFilter = new CourseFilter

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CourseFilterService.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using System.Threading.Tasks;
+using AutoMapper;
 using HwProj.CoursesService.API.Models;
 using HwProj.CoursesService.API.Repositories;
 using HwProj.Models.CoursesService;
+using HwProj.Models.CoursesService.DTO;
 using HwProj.Models.CoursesService.ViewModels;
 using HwProj.Models.Result;
 
@@ -11,11 +13,14 @@ namespace HwProj.CoursesService.API.Services
     public class CourseFilterService : ICourseFilterService
     {
         private readonly ICourseFilterRepository _courseFilterRepository;
+        private readonly IMapper _mapper;
 
         public CourseFilterService(
-            ICourseFilterRepository courseFilterRepository)
+            ICourseFilterRepository courseFilterRepository,
+            IMapper mapper)
         {
             _courseFilterRepository = courseFilterRepository;
+            _mapper = mapper;
         }
         
         public async Task<Result<long>> CreateOrUpdateCourseFilter(CreateCourseFilterModel courseFilterModel)
@@ -42,6 +47,19 @@ namespace HwProj.CoursesService.API.Services
             }
             
             return Result<long>.Success(filterId);
+        }
+
+        public async Task<Result<CourseFilterDTO>> Get(long courseId, string userId)
+        {
+            var courseFilter = await _courseFilterRepository.GetAsync(userId, courseId);
+            if (courseFilter?.Filter == null)
+            {
+                return Result<CourseFilterDTO>.Failed();
+            }
+
+            var courseFilterDto = _mapper.Map<CourseFilterDTO>(courseFilter.Filter);
+
+            return Result<CourseFilterDTO>.Success(courseFilterDto);
         }
 
         public async Task UpdateAsync(long courseFilterId, Filter filter)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICourseFilterService.cs
@@ -10,7 +10,6 @@ namespace HwProj.CoursesService.API.Services
     public interface ICourseFilterService
     {
         Task<Result<long>> CreateOrUpdateCourseFilter(CreateCourseFilterModel courseFilterModel);
-        Task<Result<CourseFilterDTO>> Get(long courseId, string userId);
         Task UpdateAsync(long courseFilterId, Filter filter);
         Task<CourseDTO[]> ApplyFiltersToCourses(string userId, CourseDTO[] courses);
         Task<CourseDTO> ApplyFilter(CourseDTO courseDto, string userId);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICourseFilterService.cs
@@ -8,7 +8,7 @@ namespace HwProj.CoursesService.API.Services
 {
     public interface ICourseFilterService
     {
-        Task<Result<long>> CreateOrUpdateExpertFilter(CreateCourseFilterModel courseFilterModel);
+        Task<Result<long>> CreateOrUpdateCourseFilter(CreateCourseFilterModel courseFilterModel);
         Task UpdateAsync(long courseFilterId, Filter filter);
         Task<CourseDTO[]> ApplyFiltersToCourses(string userId, CourseDTO[] courses);
         Task<CourseDTO> ApplyFilter(CourseDTO courseDto, string userId);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICourseFilterService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICourseFilterService.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using HwProj.CoursesService.API.Models;
 using HwProj.Models.CoursesService;
+using HwProj.Models.CoursesService.DTO;
 using HwProj.Models.CoursesService.ViewModels;
 using HwProj.Models.Result;
 
@@ -9,6 +10,7 @@ namespace HwProj.CoursesService.API.Services
     public interface ICourseFilterService
     {
         Task<Result<long>> CreateOrUpdateCourseFilter(CreateCourseFilterModel courseFilterModel);
+        Task<Result<CourseFilterDTO>> Get(long courseId, string userId);
         Task UpdateAsync(long courseFilterId, Filter filter);
         Task<CourseDTO[]> ApplyFiltersToCourses(string userId, CourseDTO[] courses);
         Task<CourseDTO> ApplyFilter(CourseDTO courseDto, string userId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -518,22 +518,6 @@ namespace HwProj.CoursesService.Client
             };
         }
 
-        public async Task<Result<CourseFilterDTO>> GetCourseFilter(long courseId, string userId)
-        {
-            using var httpRequest = new HttpRequestMessage(
-                HttpMethod.Get,
-                _coursesServiceUri + $"api/CourseFilters/get/{courseId}/{userId}");
-
-            var response = await _httpClient.SendAsync(httpRequest);
-
-            return response.StatusCode switch
-            {
-                HttpStatusCode.OK => Result<CourseFilterDTO>.Success(await response.DeserializeAsync<CourseFilterDTO>()),
-                HttpStatusCode.NotFound => Result<CourseFilterDTO>.Failed(await response.Content.ReadAsStringAsync()),
-                _ => Result<CourseFilterDTO>.Failed(),
-            };
-        }
-
         public async Task<bool> Ping()
         {
             try

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -62,6 +62,23 @@ namespace HwProj.CoursesService.Client
             return response.IsSuccessStatusCode ? await response.DeserializeAsync<CourseDTO>() : null;
         }
 
+        public async Task<Result<CourseDTO>> GetCourseByIdForMentor(long courseId, string mentorId)
+        {
+            using var httpRequest = new HttpRequestMessage(
+                HttpMethod.Get,
+                _coursesServiceUri + $"api/Courses/getForMentor/{courseId}/{mentorId}");
+
+            httpRequest.TryAddUserId(_httpContextAccessor);
+            var response = await _httpClient.SendAsync(httpRequest);
+            
+            return response.StatusCode switch
+            {
+                HttpStatusCode.OK => Result<CourseDTO>.Success(await response.DeserializeAsync<CourseDTO>()),
+                HttpStatusCode.BadRequest => Result<CourseDTO>.Failed(await response.Content.ReadAsStringAsync()),
+                _ => Result<CourseDTO>.Failed()
+            };
+        }
+
         public async Task<Result> DeleteCourse(long courseId)
         {
             using var httpRequest = new HttpRequestMessage(

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -495,8 +495,8 @@ namespace HwProj.CoursesService.Client
             
             return response.StatusCode switch
             {
-                HttpStatusCode.OK => await response.DeserializeAsync<Result<long>>(),
-                HttpStatusCode.Forbidden => Result<long>.Failed(await response.Content.ReadAsStringAsync()),
+                HttpStatusCode.OK => Result<long>.Success(await response.DeserializeAsync<long>()),
+                HttpStatusCode.BadRequest => Result<long>.Failed(await response.Content.ReadAsStringAsync()),
                 _ => Result<long>.Failed(),
             };
         }

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -501,6 +501,22 @@ namespace HwProj.CoursesService.Client
             };
         }
 
+        public async Task<Result<CourseFilterDTO>> GetCourseFilter(long courseId, string userId)
+        {
+            using var httpRequest = new HttpRequestMessage(
+                HttpMethod.Get,
+                _coursesServiceUri + $"api/CourseFilters/get/{courseId}/{userId}");
+
+            var response = await _httpClient.SendAsync(httpRequest);
+
+            return response.StatusCode switch
+            {
+                HttpStatusCode.OK => Result<CourseFilterDTO>.Success(await response.DeserializeAsync<CourseFilterDTO>()),
+                HttpStatusCode.NotFound => Result<CourseFilterDTO>.Failed(await response.Content.ReadAsStringAsync()),
+                _ => Result<CourseFilterDTO>.Failed(),
+            };
+        }
+
         public async Task<bool> Ping()
         {
             try

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -44,7 +44,6 @@ namespace HwProj.CoursesService.Client
         Task<Result<AccountDataDto[]>> GetLecturersAvailableForCourse(long courseId);
         Task<Result<string[]>> GetAllTagsForCourse(long courseId);
         Task<Result<long>> CreateOrUpdateCourseFilter(long courseId, CreateCourseFilterDTO model);
-        Task<Result<CourseFilterDTO>> GetCourseFilter(long courseId, string userId);
         Task<bool> Ping();
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -11,6 +11,7 @@ namespace HwProj.CoursesService.Client
     {
         Task<CoursePreview[]> GetAllCourses();
         Task<CourseDTO?> GetCourseById(long courseId);
+        Task<Result<CourseDTO>> GetCourseByIdForMentor(long courseId, string mentorId);
         Task<CourseDTO?> GetCourseByTask(long taskId);
         Task<Result> DeleteCourse(long courseId);
         Task<long> CreateCourse(CreateCourseViewModel model, string mentorId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -43,6 +43,7 @@ namespace HwProj.CoursesService.Client
         Task<Result<AccountDataDto[]>> GetLecturersAvailableForCourse(long courseId);
         Task<Result<string[]>> GetAllTagsForCourse(long courseId);
         Task<Result<long>> CreateOrUpdateCourseFilter(long courseId, CreateCourseFilterDTO model);
+        Task<Result<CourseFilterDTO>> GetCourseFilter(long courseId, string userId);
         Task<bool> Ping();
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -42,7 +42,7 @@ namespace HwProj.CoursesService.Client
         Task<Result> AcceptLecturer(long courseId, string lecturerEmail, string lecturerId);
         Task<Result<AccountDataDto[]>> GetLecturersAvailableForCourse(long courseId);
         Task<Result<string[]>> GetAllTagsForCourse(long courseId);
-        Task<Result<long>> CreateOrUpdateExpertCourseFilter(CreateCourseFilterModel model);
+        Task<Result<long>> CreateOrUpdateCourseFilter(long courseId, CreateCourseFilterDTO model);
         Task<bool> Ping();
     }
 }

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -2230,6 +2230,32 @@ export interface UserTaskSolutionsPageData {
     taskSolutions?: Array<UserTaskSolutions2>;
 }
 
+/**
+ *
+ * @export
+ * @interface WorkspaceViewModel
+ */
+export interface WorkspaceViewModel {
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof WorkspaceViewModel
+     */
+    studentIds?: Array<string>;
+    /**
+     *
+     * @type {Array<number>}
+     * @memberof WorkspaceViewModel
+     */
+    homeworkIds?: Array<number>;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof WorkspaceViewModel
+     */
+    mentorIds?: Array<string>;
+}
+
 
 /**
  * AccountApi - fetch parameter creator
@@ -4089,6 +4115,53 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
         },
         /**
          *
+         * @param {number} courseId
+         * @param {string} mentorId
+         * @param {WorkspaceViewModel} [workspaceViewModel]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options: any = {}): FetchArgs {
+            // verify required parameter 'courseId' is not null or undefined
+            if (courseId === null || courseId === undefined) {
+                throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost.');
+            }
+            // verify required parameter 'mentorId' is not null or undefined
+            if (mentorId === null || mentorId === undefined) {
+                throw new RequiredError('mentorId','Required parameter mentorId was null or undefined when calling apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost.');
+            }
+            const localVarPath = `/api/Courses/editMentorWorkspace/{courseId}/{mentorId}`
+                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)))
+                .replace(`{${"mentorId"}}`, encodeURIComponent(String(mentorId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json-patch+json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            localVarUrlObj.search = null;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"WorkspaceViewModel" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(workspaceViewModel || {}) : (workspaceViewModel || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4441,6 +4514,26 @@ export const CoursesApiFp = function(configuration?: Configuration) {
         },
         /**
          *
+         * @param {number} courseId
+         * @param {string} mentorId
+         * @param {WorkspaceViewModel} [workspaceViewModel]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Result> {
+            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceViewModel, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         *
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4623,6 +4716,17 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
         },
         /**
          *
+         * @param {number} courseId
+         * @param {string} mentorId
+         * @param {WorkspaceViewModel} [workspaceViewModel]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options?: any) {
+            return CoursesApiFp(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceViewModel, options)(fetch, basePath);
+        },
+        /**
+         *
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4749,6 +4853,19 @@ export class CoursesApi extends BaseAPI {
      */
     public apiCoursesCreatePost(model?: CreateCourseViewModel, options?: any) {
         return CoursesApiFp(this.configuration).apiCoursesCreatePost(model, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     *
+     * @param {number} courseId
+     * @param {string} mentorId
+     * @param {WorkspaceViewModel} [workspaceViewModel]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CoursesApi
+     */
+    public apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options?: any) {
+        return CoursesApiFp(this.configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceViewModel, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -7968,3 +8085,4 @@ export class TasksApi extends BaseAPI {
     }
 
 }
+

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -626,6 +626,26 @@ export interface EditAccountViewModel {
 /**
  *
  * @export
+ * @interface EditMentorWorkspaceDTO
+ */
+export interface EditMentorWorkspaceDTO {
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof EditMentorWorkspaceDTO
+     */
+    studentIds?: Array<string>;
+    /**
+     *
+     * @type {Array<number>}
+     * @memberof EditMentorWorkspaceDTO
+     */
+    homeworkIds?: Array<number>;
+}
+
+/**
+ *
+ * @export
  * @interface ExpertDataDTO
  */
 export interface ExpertDataDTO {
@@ -2227,21 +2247,21 @@ export interface UserTaskSolutionsPageData {
 /**
  *
  * @export
- * @interface WorkspaceDTO
+ * @interface WorkspaceViewModel
  */
-export interface WorkspaceDTO {
+export interface WorkspaceViewModel {
     /**
      *
-     * @type {Array<string>}
-     * @memberof WorkspaceDTO
+     * @type {Array<AccountDataDto>}
+     * @memberof WorkspaceViewModel
      */
-    studentIds?: Array<string>;
+    students?: Array<AccountDataDto>;
     /**
      *
-     * @type {Array<number>}
-     * @memberof WorkspaceDTO
+     * @type {Array<HomeworkViewModel>}
+     * @memberof WorkspaceViewModel
      */
-    homeworkIds?: Array<number>;
+    homeworks?: Array<HomeworkViewModel>;
 }
 
 
@@ -4105,11 +4125,11 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
          *
          * @param {number} courseId
          * @param {string} mentorId
-         * @param {WorkspaceDTO} [workspaceDto]
+         * @param {EditMentorWorkspaceDTO} [editMentorWorkspaceDto]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options: any = {}): FetchArgs {
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, editMentorWorkspaceDto?: EditMentorWorkspaceDTO, options: any = {}): FetchArgs {
             // verify required parameter 'courseId' is not null or undefined
             if (courseId === null || courseId === undefined) {
                 throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost.');
@@ -4140,8 +4160,8 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             localVarUrlObj.search = null;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-            const needsSerialization = (<any>"WorkspaceDTO" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(workspaceDto || {}) : (workspaceDto || "");
+            const needsSerialization = (<any>"EditMentorWorkspaceDTO" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(editMentorWorkspaceDto || {}) : (editMentorWorkspaceDto || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -4546,12 +4566,12 @@ export const CoursesApiFp = function(configuration?: Configuration) {
          *
          * @param {number} courseId
          * @param {string} mentorId
-         * @param {WorkspaceDTO} [workspaceDto]
+         * @param {EditMentorWorkspaceDTO} [editMentorWorkspaceDto]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
-            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceDto, options);
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, editMentorWorkspaceDto?: EditMentorWorkspaceDTO, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, editMentorWorkspaceDto, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -4604,7 +4624,7 @@ export const CoursesApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId: number, mentorId: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<WorkspaceDTO> {
+        apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId: number, mentorId: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<WorkspaceViewModel> {
             const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId, mentorId, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -4767,12 +4787,12 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
          *
          * @param {number} courseId
          * @param {string} mentorId
-         * @param {WorkspaceDTO} [workspaceDto]
+         * @param {EditMentorWorkspaceDTO} [editMentorWorkspaceDto]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options?: any) {
-            return CoursesApiFp(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceDto, options)(fetch, basePath);
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, editMentorWorkspaceDto?: EditMentorWorkspaceDTO, options?: any) {
+            return CoursesApiFp(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, editMentorWorkspaceDto, options)(fetch, basePath);
         },
         /**
          *
@@ -4918,13 +4938,13 @@ export class CoursesApi extends BaseAPI {
      *
      * @param {number} courseId
      * @param {string} mentorId
-     * @param {WorkspaceDTO} [workspaceDto]
+     * @param {EditMentorWorkspaceDTO} [editMentorWorkspaceDto]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof CoursesApi
      */
-    public apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options?: any) {
-        return CoursesApiFp(this.configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceDto, options)(this.fetch, this.basePath);
+    public apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, editMentorWorkspaceDto?: EditMentorWorkspaceDTO, options?: any) {
+        return CoursesApiFp(this.configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, editMentorWorkspaceDto, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -1051,12 +1051,6 @@ export interface InviteExpertViewModel {
      * @memberof InviteExpertViewModel
      */
     homeworkIds?: Array<number>;
-    /**
-     *
-     * @type {Array<string>}
-     * @memberof InviteExpertViewModel
-     */
-    mentorIds?: Array<string>;
 }
 
 /**
@@ -2233,27 +2227,21 @@ export interface UserTaskSolutionsPageData {
 /**
  *
  * @export
- * @interface WorkspaceViewModel
+ * @interface WorkspaceDTO
  */
-export interface WorkspaceViewModel {
+export interface WorkspaceDTO {
     /**
      *
      * @type {Array<string>}
-     * @memberof WorkspaceViewModel
+     * @memberof WorkspaceDTO
      */
     studentIds?: Array<string>;
     /**
      *
      * @type {Array<number>}
-     * @memberof WorkspaceViewModel
+     * @memberof WorkspaceDTO
      */
     homeworkIds?: Array<number>;
-    /**
-     *
-     * @type {Array<string>}
-     * @memberof WorkspaceViewModel
-     */
-    mentorIds?: Array<string>;
 }
 
 
@@ -4117,11 +4105,11 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
          *
          * @param {number} courseId
          * @param {string} mentorId
-         * @param {WorkspaceViewModel} [workspaceViewModel]
+         * @param {WorkspaceDTO} [workspaceDto]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options: any = {}): FetchArgs {
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options: any = {}): FetchArgs {
             // verify required parameter 'courseId' is not null or undefined
             if (courseId === null || courseId === undefined) {
                 throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost.');
@@ -4152,8 +4140,8 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             localVarUrlObj.search = null;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-            const needsSerialization = (<any>"WorkspaceViewModel" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(workspaceViewModel || {}) : (workspaceViewModel || "");
+            const needsSerialization = (<any>"WorkspaceDTO" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(workspaceDto || {}) : (workspaceDto || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -4203,6 +4191,48 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
             }
             const localVarPath = `/api/Courses/getLecturersAvailableForCourse/{courseId}`
                 .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            localVarUrlObj.search = null;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {number} courseId
+         * @param {string} mentorId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId: number, mentorId: string, options: any = {}): FetchArgs {
+            // verify required parameter 'courseId' is not null or undefined
+            if (courseId === null || courseId === undefined) {
+                throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet.');
+            }
+            // verify required parameter 'mentorId' is not null or undefined
+            if (mentorId === null || mentorId === undefined) {
+                throw new RequiredError('mentorId','Required parameter mentorId was null or undefined when calling apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet.');
+            }
+            const localVarPath = `/api/Courses/getMentorWorkspace/{courseId}/{mentorId}`
+                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)))
+                .replace(`{${"mentorId"}}`, encodeURIComponent(String(mentorId)));
             const localVarUrlObj = url.parse(localVarPath, true);
             const localVarRequestOptions = Object.assign({ method: 'GET' }, options);
             const localVarHeaderParameter = {} as any;
@@ -4516,16 +4546,16 @@ export const CoursesApiFp = function(configuration?: Configuration) {
          *
          * @param {number} courseId
          * @param {string} mentorId
-         * @param {WorkspaceViewModel} [workspaceViewModel]
+         * @param {WorkspaceDTO} [workspaceDto]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Result> {
-            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceViewModel, options);
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceDto, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
-                        return response.json();
+                        return response;
                     } else {
                         throw response;
                     }
@@ -4557,6 +4587,25 @@ export const CoursesApiFp = function(configuration?: Configuration) {
          */
         apiCoursesGetLecturersAvailableForCourseByCourseIdGet(courseId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Array<AccountDataDto>> {
             const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesGetLecturersAvailableForCourseByCourseIdGet(courseId, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         *
+         * @param {number} courseId
+         * @param {string} mentorId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId: number, mentorId: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<WorkspaceDTO> {
+            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId, mentorId, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -4718,12 +4767,12 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
          *
          * @param {number} courseId
          * @param {string} mentorId
-         * @param {WorkspaceViewModel} [workspaceViewModel]
+         * @param {WorkspaceDTO} [workspaceDto]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options?: any) {
-            return CoursesApiFp(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceViewModel, options)(fetch, basePath);
+        apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options?: any) {
+            return CoursesApiFp(configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceDto, options)(fetch, basePath);
         },
         /**
          *
@@ -4741,6 +4790,16 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
          */
         apiCoursesGetLecturersAvailableForCourseByCourseIdGet(courseId: number, options?: any) {
             return CoursesApiFp(configuration).apiCoursesGetLecturersAvailableForCourseByCourseIdGet(courseId, options)(fetch, basePath);
+        },
+        /**
+         *
+         * @param {number} courseId
+         * @param {string} mentorId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId: number, mentorId: string, options?: any) {
+            return CoursesApiFp(configuration).apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId, mentorId, options)(fetch, basePath);
         },
         /**
          *
@@ -4859,13 +4918,13 @@ export class CoursesApi extends BaseAPI {
      *
      * @param {number} courseId
      * @param {string} mentorId
-     * @param {WorkspaceViewModel} [workspaceViewModel]
+     * @param {WorkspaceDTO} [workspaceDto]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof CoursesApi
      */
-    public apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceViewModel?: WorkspaceViewModel, options?: any) {
-        return CoursesApiFp(this.configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceViewModel, options)(this.fetch, this.basePath);
+    public apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId: number, mentorId: string, workspaceDto?: WorkspaceDTO, options?: any) {
+        return CoursesApiFp(this.configuration).apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(courseId, mentorId, workspaceDto, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -4887,6 +4946,18 @@ export class CoursesApi extends BaseAPI {
      */
     public apiCoursesGetLecturersAvailableForCourseByCourseIdGet(courseId: number, options?: any) {
         return CoursesApiFp(this.configuration).apiCoursesGetLecturersAvailableForCourseByCourseIdGet(courseId, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     *
+     * @param {number} courseId
+     * @param {string} mentorId
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CoursesApi
+     */
+    public apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId: number, mentorId: string, options?: any) {
+        return CoursesApiFp(this.configuration).apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(courseId, mentorId, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/hwproj.front/src/components/Courses/CourseFilter.tsx
+++ b/hwproj.front/src/components/Courses/CourseFilter.tsx
@@ -1,0 +1,161 @@
+﻿import React, {FC, useEffect, useState} from 'react';
+import {HomeworkViewModel, AccountDataDto} from '../../api';
+import Grid from "@material-ui/core/Grid";
+import {Autocomplete} from "@mui/material";
+import TextField from "@material-ui/core/TextField";
+import ApiSingleton from "../../api/ApiSingleton";
+import ErrorsHandler from "../Utils/ErrorsHandler";
+import {CircularProgress} from "@material-ui/core";
+
+interface ICourseFilterProps {
+    courseId: number;
+    mentorId: string;
+    onSelectedHomeworksChange: (homeworks: HomeworkViewModel[]) => void;
+    onSelectedStudentsChange: (students: AccountDataDto[]) => void;
+    onWorkspaceInitialize: (success: boolean, errors?: string[]) => void;
+}
+
+interface ICourseFilterState {
+    courseHomeworks: HomeworkViewModel[];
+    courseStudents: AccountDataDto[];
+    selectedHomeworks: HomeworkViewModel[];
+    selectedStudents: AccountDataDto[];
+}
+
+// Если преподаватель не выбрал ни одного студента, по умолчанию регистрируем всех. Аналогично с выбором домашних работ
+const CourseFilter: FC<ICourseFilterProps> = (props) => {
+    const [state, setState] = useState<ICourseFilterState>({
+        courseHomeworks: [],
+        courseStudents: [],
+        selectedHomeworks: [],
+        selectedStudents: []
+    });
+
+    // Для отображения элемента загрузки
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+
+    // Если у преподавателя в workspace все студенты, отображаем "Все" в компоненте.
+    // Функция, необходимые для корректного отображения и передачи данных родителю
+    function processSelectedItems<T>(selected: T[], all: T[]): T[] {
+        return selected.length === 0 ? all : selected;
+    }
+
+    useEffect(() => {
+        const fetchCourseDataForMentor = async () => {
+            try {
+                const courseViewModel = await ApiSingleton.coursesApi.apiCoursesByCourseIdGet(props.courseId);
+                const mentorWorkspace =
+                    await ApiSingleton.coursesApi.apiCoursesGetMentorWorkspaceByCourseIdByMentorIdGet(props.courseId, props.mentorId);
+
+                props.onSelectedStudentsChange(mentorWorkspace.students ?? [])
+                props.onSelectedHomeworksChange(mentorWorkspace.homeworks ?? [])
+
+                // Для корректного отображения "Все" при инцициализации (получении данных с бэкенда)
+                const initSelectedStudentsView = mentorWorkspace.students?.length === courseViewModel.acceptedStudents?.length ?
+                    [] : (mentorWorkspace.students) ?? [];
+                const initSelectedHomeworksView = mentorWorkspace.homeworks?.length === courseViewModel.homeworks?.length ?
+                    [] : (mentorWorkspace.homeworks ?? []);
+
+                setState(prevState => ({
+                    ...prevState,
+                    courseHomeworks: courseViewModel.homeworks ?? [],
+                    courseStudents: courseViewModel.acceptedStudents ?? [],
+                    selectedStudents: initSelectedStudentsView,
+                    selectedHomeworks: initSelectedHomeworksView
+                }))
+
+                setIsLoading(false);
+                props.onWorkspaceInitialize(true);
+            } catch (e) {
+                const errors = await ErrorsHandler.getErrorMessages(e);
+                setState((prevState) => ({
+                    ...prevState,
+                    errors: errors
+                }))
+                setIsLoading(false);
+                props.onWorkspaceInitialize(false, errors);
+            }
+        }
+
+        fetchCourseDataForMentor();
+    }, [])
+
+    return (
+        <div>
+            {isLoading ? (
+                <div className="container" style={{paddingLeft: "40px"}}>
+                    <p>Загружаем данные...</p>
+                    <CircularProgress/>
+                </div>
+            ) : (
+                <Grid container style={{marginTop: '10px'}}>
+                    <Grid container spacing={2} style={{marginTop: '2px'}}>
+                        <Grid item xs={12} sm={12}>
+                            <Autocomplete
+                                multiple
+                                fullWidth
+                                options={state.courseHomeworks}
+                                getOptionLabel={(option: HomeworkViewModel) => option.title ?? "Без названия"}
+                                filterSelectedOptions
+                                isOptionEqualToValue={(option, value) => option.id === value.id}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        variant="outlined"
+                                        label={state.selectedHomeworks.length === 0 ? "" : "Домашние работы"}
+                                        placeholder={state.selectedHomeworks.length === 0 ? "Все домашние работы" : ""}
+                                    />
+                                )}
+                                noOptionsText={'На курсе больше нет домашних работ'}
+                                value={state.selectedHomeworks}
+                                onChange={(_, values) => {
+                                    setState((prevState) => ({
+                                        ...prevState,
+                                        selectedHomeworks: values,
+                                    }))
+
+                                    const processedValues = processSelectedItems(
+                                        values, state.courseHomeworks)
+                                    props.onSelectedHomeworksChange(processedValues)
+                                }}
+                            />
+                        </Grid>
+                    </Grid>
+                    <Grid container spacing={2} style={{marginTop: '12px'}}>
+                        <Grid item xs={12} sm={12}>
+                            <Autocomplete
+                                multiple
+                                fullWidth
+                                options={state.courseStudents}
+                                getOptionLabel={(option: AccountDataDto) => option.name + ' ' + option.surname}
+                                filterSelectedOptions
+                                isOptionEqualToValue={(option, value) => option.userId === value.userId}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        variant="outlined"
+                                        label={state.selectedStudents.length === 0 ? "" : "Студенты"}
+                                        placeholder={state.selectedStudents.length === 0 ? "Все студенты" : ""}
+                                    />)}
+                                noOptionsText={'На курсе больше нет студентов'}
+                                value={state.selectedStudents}
+                                onChange={(_, values) => {
+                                    setState((prevState) => ({
+                                        ...prevState,
+                                        selectedStudents: values
+                                    }));
+
+                                    const processedValues = processSelectedItems(
+                                        values, state.courseStudents);
+                                    props.onSelectedStudentsChange(processedValues);
+                                }}
+                            />
+                        </Grid>
+                    </Grid>
+                </Grid>
+            )}
+        </div>
+    )
+}
+
+export default CourseFilter;

--- a/hwproj.front/src/components/Courses/CourseFilter.tsx
+++ b/hwproj.front/src/components/Courses/CourseFilter.tsx
@@ -6,6 +6,7 @@ import TextField from "@material-ui/core/TextField";
 import ApiSingleton from "../../api/ApiSingleton";
 import ErrorsHandler from "../Utils/ErrorsHandler";
 import {CircularProgress} from "@material-ui/core";
+import Button from "@material-ui/core/Button";
 
 interface ICourseFilterProps {
     courseId: number;
@@ -13,6 +14,7 @@ interface ICourseFilterProps {
     onSelectedHomeworksChange: (homeworks: HomeworkViewModel[]) => void;
     onSelectedStudentsChange: (students: AccountDataDto[]) => void;
     onWorkspaceInitialize: (success: boolean, errors?: string[]) => void;
+    isStudentsSelectionHidden: boolean;
 }
 
 interface ICourseFilterState {
@@ -31,8 +33,11 @@ const CourseFilter: FC<ICourseFilterProps> = (props) => {
         selectedStudents: []
     });
 
-    // Для отображения элемента загрузки
+    // Состояние для отображения элемента загрузки
     const [isLoading, setIsLoading] = useState<boolean>(true);
+
+    // Состояние для отображения поля выбора студентов
+    const [isStudentsSelectionHidden, setIsStudentsSelectionHidden] = useState<boolean>(props.isStudentsSelectionHidden);
 
     // Если у преподавателя в workspace все студенты, отображаем "Все" в компоненте.
     // Функция, необходимые для корректного отображения и передачи данных родителю
@@ -83,7 +88,7 @@ const CourseFilter: FC<ICourseFilterProps> = (props) => {
     return (
         <div>
             {isLoading ? (
-                <div className="container" style={{paddingLeft: "40px"}}>
+                <div className="container">
                     <p>Загружаем данные...</p>
                     <CircularProgress/>
                 </div>
@@ -121,37 +126,47 @@ const CourseFilter: FC<ICourseFilterProps> = (props) => {
                             />
                         </Grid>
                     </Grid>
-                    <Grid container spacing={2} style={{marginTop: '12px'}}>
-                        <Grid item xs={12} sm={12}>
-                            <Autocomplete
-                                multiple
-                                fullWidth
-                                options={state.courseStudents}
-                                getOptionLabel={(option: AccountDataDto) => option.name + ' ' + option.surname}
-                                filterSelectedOptions
-                                isOptionEqualToValue={(option, value) => option.userId === value.userId}
-                                renderInput={(params) => (
-                                    <TextField
-                                        {...params}
-                                        variant="outlined"
-                                        label={state.selectedStudents.length === 0 ? "" : "Студенты"}
-                                        placeholder={state.selectedStudents.length === 0 ? "Все студенты" : ""}
-                                    />)}
-                                noOptionsText={'На курсе больше нет студентов'}
-                                value={state.selectedStudents}
-                                onChange={(_, values) => {
-                                    setState((prevState) => ({
-                                        ...prevState,
-                                        selectedStudents: values
-                                    }));
+                    {isStudentsSelectionHidden ? (
+                        <div style={{marginTop: '15px'}}>
+                            <Button size={"small"} color="primary"
+                                    onClick={() => setIsStudentsSelectionHidden(false)}>
+                                Выбрать студентов
+                            </Button>
+                        </div>
+                    ) : (
+                        <Grid container spacing={2} style={{marginTop: '12px'}}>
+                            <Grid item xs={12} sm={12}>
+                                <Autocomplete
+                                    multiple
+                                    fullWidth
+                                    options={state.courseStudents}
+                                    getOptionLabel={(option: AccountDataDto) => option.name + ' ' + option.surname}
+                                    filterSelectedOptions
+                                    isOptionEqualToValue={(option, value) => option.userId === value.userId}
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            variant="outlined"
+                                            label={state.selectedStudents.length === 0 ? "" : "Студенты"}
+                                            placeholder={state.selectedStudents.length === 0 ? "Все студенты" : ""}
+                                        />)}
+                                    noOptionsText={'На курсе больше нет студентов'}
+                                    value={state.selectedStudents}
+                                    onChange={(_, values) => {
+                                        setState((prevState) => ({
+                                            ...prevState,
+                                            selectedStudents: values
+                                        }));
 
-                                    const processedValues = processSelectedItems(
-                                        values, state.courseStudents);
-                                    props.onSelectedStudentsChange(processedValues);
-                                }}
-                            />
+                                        const processedValues = processSelectedItems(
+                                            values, state.courseStudents);
+                                        props.onSelectedStudentsChange(processedValues);
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                    </Grid>
+
+                    )}
                 </Grid>
             )}
         </div>

--- a/hwproj.front/src/components/Courses/Lecturers.tsx
+++ b/hwproj.front/src/components/Courses/Lecturers.tsx
@@ -1,18 +1,31 @@
 import React, {FC, useState} from 'react'
 import List from "@material-ui/core/List";
-import {Link, ListItem, Typography, Accordion, AccordionSummary, AccordionDetails} from "@material-ui/core";
+import { Link, ListItem, Typography, Accordion, AccordionSummary,
+    AccordionDetails, Grid, ListItemIcon, Avatar} from "@material-ui/core";
 import {AccountDataDto} from "../../api";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import IconButton from "@material-ui/core/IconButton";
 import PersonAddIcon from "@material-ui/icons/PersonAdd";
 import AddLecturerInCourse from "./AddLecturerInCourse";
 import {makeStyles} from "@material-ui/styles";
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText';
+import MentorWorkspaceModal from "./MentorWorkspaceModal";
+import AvatarUtils from "../Utils/AvatarUtils";
 
 interface LecturersProps {
     mentors: AccountDataDto[];
     courseId: string;
     isEditCourse: boolean;
     update: any;
+}
+
+interface EditMentorWorkspaceState {
+    mentorId: string;
+    mentorName: string;
+    mentorSurname: string;
+    isOpen: boolean;
 }
 
 const useStyles = makeStyles(theme => ({
@@ -31,12 +44,37 @@ const Lecturers: FC<LecturersProps> = (props) => {
 
     const [isOpenDialogAddLecturer, setIsOpenDialogAddLecturer] = useState<boolean>(false)
 
+    const [mentorWorkspaceState, setMentorWorkspaceState] = useState<EditMentorWorkspaceState>({
+        mentorId: "",
+        mentorName: "",
+        mentorSurname: "",
+        isOpen: false
+    })
+
     const openDialogIconAddLecturer = () => {
         setIsOpenDialogAddLecturer(true)
     }
 
     const closeDialogIconAddLecturer = () => {
         setIsOpenDialogAddLecturer(false)
+    }
+
+    const handleOpenMentorControl = (userId: string, name: string, surname: string) => {
+        setMentorWorkspaceState({
+            mentorId: userId,
+            mentorName: name,
+            mentorSurname: surname,
+            isOpen: true
+        })
+    }
+
+    const handleCloseMentorControl = () => {
+        setMentorWorkspaceState({
+            mentorId: "",
+            mentorName: "",
+            mentorSurname: "",
+            isOpen: false
+        })
     }
 
     const classes = useStyles()
@@ -64,23 +102,37 @@ const Lecturers: FC<LecturersProps> = (props) => {
                     </div>
                 </AccordionSummary>
                 <AccordionDetails>
-                    <List>
-                        {props.mentors.map(mentor =>
-                            <div>
-                                <ListItem>
-                                    <Link
-                                        color="inherit"
-                                        component="button"
-                                        onClick={() => window.location.href = "mailto:" + mentor.email}
-                                    >
-                                        <Typography style={{ fontSize: '16px'}}>
-                                            {mentor.name}&nbsp;{mentor.surname}
-                                        </Typography>
-                                    </Link>
+                    <Grid container direction="column">
+                        <List>
+                            {props.mentors.map(mentor =>
+                                <ListItem dense={true}>
+                                    <ListItemIcon>
+                                        <Avatar {...AvatarUtils.stringAvatar(mentor!)} />
+                                    </ListItemIcon>
+                                    <ListItemText>
+                                        <Link
+                                            color="inherit"
+                                            component="button"
+                                            onClick={() => window.location.href = "mailto:" + mentor.email}
+                                        >
+                                            <Typography style={{fontSize: '16px'}}>
+                                                {mentor.name}&nbsp;{mentor.surname}
+                                            </Typography>
+                                        </Link>
+                                    </ListItemText>
+                                    <ListItemSecondaryAction>
+                                        <IconButton
+                                            edge="end"
+                                            onClick={() => handleOpenMentorControl(mentor.userId!, mentor.name!, mentor.surname!)}
+                                            style={{color: '#212529'}}
+                                        >
+                                            <ManageAccountsIcon fontSize="small"/>
+                                        </IconButton>
+                                    </ListItemSecondaryAction>
                                 </ListItem>
-                            </div>
-                        )}
-                    </List>
+                            )}
+                        </List>
+                    </Grid>
                 </AccordionDetails>
             </Accordion>
             <AddLecturerInCourse
@@ -89,6 +141,15 @@ const Lecturers: FC<LecturersProps> = (props) => {
                 isOpen={isOpenDialogAddLecturer}
                 update={props.update}
             />
+            {mentorWorkspaceState.isOpen && (
+                <MentorWorkspaceModal
+                    isOpen={mentorWorkspaceState.isOpen}
+                    onClose={handleCloseMentorControl}
+                    courseId={+props.courseId}
+                    mentorId={mentorWorkspaceState.mentorId}
+                    mentorName={mentorWorkspaceState.mentorName}
+                    mentorSurname={mentorWorkspaceState.mentorSurname}
+                />)}
         </div>
     )
 }

--- a/hwproj.front/src/components/Courses/MentorWorkspaceModal.tsx
+++ b/hwproj.front/src/components/Courses/MentorWorkspaceModal.tsx
@@ -87,6 +87,7 @@ const MentorWorkspaceModal: FC<MentorWorkspaceProps> = (props) => {
                             </Typography>}
                         <CourseFilter courseId={props.courseId}
                                       mentorId={props.mentorId}
+                                      isStudentsSelectionHidden={false}
                                       onSelectedHomeworksChange={(homeworks) =>
                                           setState(prevState => ({
                                               ...prevState,

--- a/hwproj.front/src/components/Courses/MentorWorkspaceModal.tsx
+++ b/hwproj.front/src/components/Courses/MentorWorkspaceModal.tsx
@@ -1,0 +1,253 @@
+﻿import React, {FC, useEffect, useState} from 'react'
+import {makeStyles} from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import ApiSingleton from "../../api/ApiSingleton";
+import Typography from "@material-ui/core/Typography";
+import Grid from '@material-ui/core/Grid';
+import {
+    HomeworkViewModel,
+    AccountDataDto,
+    WorkspaceViewModel
+} from "../../api";
+import {Autocomplete} from "@mui/material";
+
+interface MentorWorkspaceProps {
+    isOpen: boolean;
+    onClose: any;
+    mentorId: string;
+    courseId: number;
+    mentorName: string;
+    mentorSurname: string;
+}
+
+interface MentorWorkspaceState {
+    courseHomeworks: HomeworkViewModel[];
+    courseStudents: AccountDataDto[];
+    selectedHomeworks: HomeworkViewModel[];
+    selectedStudents: AccountDataDto[];
+    errors: string[];
+}
+
+const MentorWorkspaceModal: FC<MentorWorkspaceProps> = (props) => {
+    const [state, setState] = useState<MentorWorkspaceState>({
+        courseHomeworks: [],
+        courseStudents: [],
+        selectedHomeworks: [],
+        selectedStudents: [],
+        errors: []
+    });
+
+    const [isInviteButtonDisabled, setIsInviteButtonDisabled]
+        = useState<boolean>(true); // Состояние для блокировки кнопки "Изменить"
+
+    const [isLinkCopied, setIsLinkCopied]
+        = useState<boolean>(false); // Состояние для отображения сообщения "Ссылка скопирована"
+
+    const [isInvited, setIsInvited]
+        = useState<boolean>(false); // Состояние для скрытия кнопки "Изменить"
+
+    // Получаем всех возможных студентов и все возможные домашние работы курса.
+    useEffect(() => {
+        const fetchCourseData = async () => {
+            const courseViewModel = await ApiSingleton.coursesApi.apiCoursesByCourseIdGet(props.courseId);
+            setState(prevState => ({
+                ...prevState,
+                courseHomeworks: courseViewModel.homeworks ?? [],
+                courseStudents: courseViewModel.acceptedStudents ?? []
+            }));
+        };
+
+        fetchCourseData();
+    }, [])
+
+    // useEffect(() => {
+    //     // Здесь будем получать текущих выбранных студентов и домашние работы.
+    //     const fetchCourses = async () => {
+    //         const courses = await ApiSingleton.coursesApi.apiCoursesUserCoursesGet();
+    //         setState(prevState => ({
+    //             ...prevState,
+    //             lecturerCourses: courses
+    //         }));
+    //     }
+    //
+    //     fetchCourses();
+    // }, [])
+
+    // Здесь работаем с кнопкой изменить: пока выбранные студенты и домашки совпадают с ранее выбранными, кнопка заблокирована
+    useEffect(() => {
+        const controlItemsAccessibility = () => {
+            //setIsInviteButtonDisabled(!isInputAllowed);
+        }
+
+        controlItemsAccessibility();
+    }, [state.selectedStudents, state.selectedHomeworks])
+
+    // Если преподаватель не выбрал ни одного студента, по умолчанию регистрируем всех. Аналогично с выбором домашних работ
+    const handleInvitation = async () => {
+        try {
+            const workspaceViewModel: WorkspaceViewModel = {
+                homeworkIds: state.selectedHomeworks.length === 0 ?
+                    state.courseHomeworks.map(homeworkViewModel => homeworkViewModel.id!)
+                    : state.selectedHomeworks.map(homeworkViewModel => homeworkViewModel.id!),
+                studentIds: state.selectedStudents.length === 0 ?
+                    state.courseStudents.map(accountData => accountData.userId!)
+                    : state.selectedStudents.map(accountData => accountData.userId!),
+                mentorIds: []
+            }
+            const result = await ApiSingleton.coursesApi.apiCoursesEditMentorWorkspaceByCourseIdByMentorIdPost(
+                props.courseId, props.mentorId, workspaceViewModel
+            );
+            
+            if (result.succeeded) {
+                setIsInviteButtonDisabled(true);
+                setIsInvited(true);
+            }
+            setState((prevState) => ({
+                ...prevState,
+                errors: result!.errors ?? [],
+            }));
+        } catch (e) {
+            const responseErrors = await e.json()
+            setState((prevState) => ({
+                ...prevState,
+                errors: responseErrors ?? ['Сервис недоступен']
+            }))
+        }
+    }
+
+    return (
+        <div>
+            <Dialog open={props.isOpen} onClose={props.onClose} aria-labelledby="dialog-title" fullWidth>
+                <DialogTitle id="dialog-title">
+                    {props.mentorName}&nbsp;{props.mentorSurname}
+                </DialogTitle>
+                <DialogContent>
+                    <Grid item container direction={"row"} justifyContent={"center"}>
+                        {state.errors.length > 0 && (
+                            <p style={{color: "red", marginBottom: "5px"}}>{state.errors}</p>
+                        )}
+                    </Grid>
+                    <Typography>
+                        Здесь вы можете изменить область работы преподавателя.
+                    </Typography>
+                    <Grid container style={{marginTop: '10px'}}>
+                        <Grid container>
+                            <Typography>
+                                Задачи:
+                            </Typography>
+                            <Grid container spacing={2} style={{marginTop: '2px'}}>
+                                <Grid item xs={12} sm={12}>
+                                    <Autocomplete
+                                        multiple
+                                        fullWidth
+                                        options={state.courseHomeworks}
+                                        getOptionLabel={(option: HomeworkViewModel) => option.title ?? "Без названия"}
+                                        filterSelectedOptions
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                variant="outlined"
+                                                label={state.selectedHomeworks.length === 0 ? "" : "Домашние работы"}
+                                                placeholder={state.selectedHomeworks.length === 0 ? "Все домашние работы" : ""}
+                                            />
+                                        )}
+                                        noOptionsText={'На курсе больше нет домашних работ'}
+                                        value={state.selectedHomeworks}
+                                        onChange={(_, values) => {
+                                            setState(prevState => ({
+                                                ...prevState,
+                                                selectedHomeworks: values
+                                            }));
+                                        }}
+                                    />
+                                </Grid>
+                            </Grid>
+                        </Grid>
+                        <Grid container style={{marginTop: '10px'}}>
+                            <Typography>
+                                Студенты:
+                            </Typography>
+                            <Grid container spacing={2} style={{marginTop: '2px'}}>
+                                <Grid item xs={12} sm={12}>
+                                    <Autocomplete
+                                        multiple
+                                        fullWidth
+                                        options={state.courseStudents}
+                                        getOptionLabel={(option: AccountDataDto) => option.name + ' ' + option.surname}
+                                        filterSelectedOptions
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                variant="outlined"
+                                                label={state.selectedStudents.length === 0 ? "" : "Студенты"}
+                                                placeholder={state.selectedStudents.length === 0 ? "Все студенты" : ""}
+                                            />)}
+                                        noOptionsText={'На курсе больше нет студентов'}
+                                        value={state.selectedStudents}
+                                        onChange={(_, values) => {
+                                            setState(prevState => ({
+                                                ...prevState,
+                                                selectedStudents: values
+                                            }));
+                                        }}
+                                    />
+                                </Grid>
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                    <Grid
+                        direction="row"
+                        justifyContent="flex-end"
+                        alignItems="flex-end"
+                        container
+                        style={{marginTop: '15px'}}
+                    >
+                        <Grid item>
+                            <Button
+                                onClick={props.onClose}
+                                color="primary"
+                                variant="contained"
+                                style={{marginRight: '10px'}}
+                            >
+                                Закрыть
+                            </Button>
+                        </Grid>
+                        <Grid item>
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={handleInvitation}
+                                disabled={isInviteButtonDisabled}
+                            >
+                                Изменить
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </DialogContent>
+                <DialogActions>
+                </DialogActions>
+                {isLinkCopied && (
+                    <div style={{
+                        position: 'fixed',
+                        bottom: '20px',
+                        right: '20px',
+                        backgroundColor: '#3F51B5',
+                        color: 'white',
+                        padding: '10px',
+                        borderRadius: '5px',
+                        zIndex: 1000
+                    }}>
+                        Ссылка скопирована в буфер обмена
+                    </div>
+                )}
+            </Dialog>
+        </div>
+    )
+}
+
+export default MentorWorkspaceModal;

--- a/hwproj.front/src/components/Experts/InviteModal.tsx
+++ b/hwproj.front/src/components/Experts/InviteModal.tsx
@@ -132,8 +132,7 @@ const InviteExpertModal: FC<IInviteExpertProps> = (props) => {
                     : state.selectedHomeworks.map(homeworkViewModel => homeworkViewModel.id!),
                 studentIds: state.selectedStudents.length === 0 ?
                     state.courseStudents.map(accountData => accountData.userId!)
-                    : state.selectedStudents.map(accountData => accountData.userId!),
-                mentorIds: []
+                    : state.selectedStudents.map(accountData => accountData.userId!)
             }
             const result = await ApiSingleton.expertsApi.apiExpertsInvitePost(inviteExpertModel);
             if (result.succeeded) {

--- a/hwproj.front/src/components/Utils/ErrorsHandler.tsx
+++ b/hwproj.front/src/components/Utils/ErrorsHandler.tsx
@@ -1,0 +1,10 @@
+﻿export default class ErrorsHandler {
+    static async getErrorMessages(response : Response) : Promise<string[]> {
+        try {
+            const message = await response.text();
+            return [message];
+        } catch {
+            return ['Сервис недоступен'];
+        }
+    }
+}

--- a/hwproj.front/src/components/Utils/ErrorsHandler.tsx
+++ b/hwproj.front/src/components/Utils/ErrorsHandler.tsx
@@ -1,10 +1,20 @@
 ﻿export default class ErrorsHandler {
-    static async getErrorMessages(response : Response) : Promise<string[]> {
+    static defaultErrorMessage = 'Сервис недоступен';
+
+    static isStringNullOrEmpty(str: string | undefined): boolean {
+        return str === undefined || str.trim().length === 0;
+    }
+
+    static async getErrorMessages(response: Response): Promise<string[]> {
         try {
             const message = await response.text();
+            if (this.isStringNullOrEmpty(message)) {
+                return [this.defaultErrorMessage];
+            }
+
             return [message];
         } catch {
-            return ['Сервис недоступен'];
+            return [this.defaultErrorMessage];
         }
     }
 }


### PR DESCRIPTION
Задачи:
- поддержать фильтры курсов для преподавателей;
- реализовать функциональность по распределению задач и студентов для экспертов и преподавателей со страницы редактирования курса (версия страницы из главной ветки приведена на скриншоте).
![photo_2024-09-30_04-38-17](https://github.com/user-attachments/assets/74699fa6-ba1e-496a-86ac-4874e203c563)

Результаты:
- обновленный список менторов;<img src="https://github.com/user-attachments/assets/94e99cba-21fe-45a5-b268-00424b51683c" width="750">

- изменение задач и студентов у ментора.<img src="https://github.com/user-attachments/assets/a1ffdc6b-7b93-4712-88ae-b94aca3d0542" width="600"><img src="https://github.com/user-attachments/assets/789bba37-87e6-408b-b103-20253eccc2ce" width="600">

Демонстрация:

[Рабочая область преподавателей](https://github.com/user-attachments/assets/3a551465-5e26-402a-a6e7-41bceb491aaf)
