### PR TITLE
CourseMentorOnlyAttribute improvement

### DIFF
--- a/HwProj.CoursesService/HwProj.CoursesService.API/Filters/CourseMentorOnlyAttribute.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Filters/CourseMentorOnlyAttribute.cs
@@ -49,7 +49,13 @@ namespace HwProj.CoursesService.API.Filters
 
             if (mentorIds != null && !mentorIds.Contains(userId.ToString()))
             {
-                context.Result = new StatusCodeResult(StatusCodes.Status403Forbidden);
+                context.Result = new ContentResult
+                {
+                    StatusCode = StatusCodes.Status403Forbidden,
+                    Content = "Недостаточно прав: Вы не являетесь ментором на курсе.",
+                    ContentType = "application/json"
+                };
+                return;
             }
 
             await next.Invoke();

--- a/hwproj.front/src/components/Experts/InviteModal.tsx
+++ b/hwproj.front/src/components/Experts/InviteModal.tsx
@@ -152,9 +152,10 @@ const InviteExpertModal: FC<IInviteExpertProps> = (props) => {
                 errors: result!.errors ?? [],
             }));
         } catch (e) {
+            const responseErrors = await e.json()
             setState((prevState) => ({
                 ...prevState,
-                errors: ['Сервис недоступен'],
+                errors: responseErrors ?? ['Сервис недоступен'] 
             }))
         }
     }


### PR DESCRIPTION
PR решает проблему возникновения исключений на бэкенде при присваивании ``context.Result`` в коде атрибута ``CourseMentorOnly``, а также реализует механизм передачи информации об ошибке на фронтенд для отображения пользователю (вместо надписи 'Сервис недоступен' с возвращаемым кодом от сервера = 500, что некорректно).

Для корректной передачи сообщения об ошибке требуется также правильно реализовывать методы клиентов: например, как в [#431](https://github.com/InteIIigeNET/HwProj-2.0.1/pull/431):
```
return response.StatusCode switch
{
    HttpStatusCode.OK => await response.DeserializeAsync<Result<long>>(),
    HttpStatusCode.Forbidden => Result<long>.Failed(await response.Content.ReadAsStringAsync()),
    _ => Result<long>.Failed(),
};
```

Для полноценного улучшения потребуется:
- на фронтенде получать текст потенциальной ошибки во всех местах, где сейчас присутствует только надпись 'Сервис недоступен';
- правильно обрабатывать случай ``HttpStatusCode.Forbidden`` во всех методах клиентов, отправляющих запросы к функциям с фильтрами ``CourseMentorOnlyAttribute``.