### PR TITLE
Улучшение функциональности по Приглашению экспертов (фронтенд)

### DIFF
--- a/hwproj.front/src/components/Courses/Course.tsx
+++ b/hwproj.front/src/components/Courses/Course.tsx
@@ -18,6 +18,7 @@ import {useParams, useNavigate} from 'react-router-dom';
 import MentorsList from "../Common/MentorsList";
 import LecturerStatistics from "./Statistics/LecturerStatistics";
 import AssessmentIcon from '@mui/icons-material/Assessment';
+import NameBuilder from "../Utils/NameBuilder";
 
 type TabValue = "homeworks" | "stats" | "applications"
 
@@ -188,7 +189,7 @@ const Course: React.FC = () => {
                         <Grid item container xs={12} className={classes.info} alignItems="center" justifyContent="space-between">
                             <Grid item>
                                 <Typography style={{fontSize: '22px'}}>
-                                    {`${course.name} / ${course.groupName}`} &nbsp;
+                                    {NameBuilder.getCourseFullName(course.name!, course.groupName)} &nbsp;
                                     {isLecturer &&
                                         <IconButton
                                             size="small"

--- a/hwproj.front/src/components/Courses/CoursesList.tsx
+++ b/hwproj.front/src/components/Courses/CoursesList.tsx
@@ -3,6 +3,7 @@ import {CoursePreviewView} from "../../api/";
 import {NavLink} from "react-router-dom";
 import MentorsList from "../Common/MentorsList";
 import {Box, Divider, Grid, ListItem, Typography} from "@mui/material";
+import NameBuilder from "../Utils/NameBuilder";
 
 interface ICoursesProps {
     navigate: any
@@ -28,7 +29,7 @@ export class CoursesList extends React.Component<ICoursesProps, {}> {
                                     style={{color: "#212529"}}
                                 >
                                     <Typography style={{fontSize: "20px"}}>
-                                        {course.name} {course.groupName?.length != 0 ? "/ " + course.groupName : ""}
+                                        {NameBuilder.getCourseFullName(course.name!, course.groupName)}
                                     </Typography>
                                 </NavLink>
                             </ListItem>

--- a/hwproj.front/src/components/Courses/NewCourseEvents.tsx
+++ b/hwproj.front/src/components/Courses/NewCourseEvents.tsx
@@ -5,6 +5,7 @@ import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import * as React from "react";
 import {Link} from "react-router-dom";
 import Utils from "../../services/Utils";
+import NameBuilder from "../Utils/NameBuilder";
 
 const courseEventPlurals = ["новая заявка", "новые заявки", "новых заявок"]
 
@@ -20,7 +21,7 @@ const NewCourseEvents: FC<{
                         <CardContent>
                             <Stack direction={"row"} alignItems={"center"} spacing={1}>
                                 <Typography variant={"subtitle1"}>
-                                    {event.name} {event.groupName?.length != 0 ? "/ " + event.groupName : ""}
+                                    {NameBuilder.getCourseFullName(event.name!, event.groupName)}
                                 </Typography>
                                 {event.isCompleted && <Chip style={{color: "GrayText"}} label="Курс завершен" size={"small"}/>}
                             </Stack>

--- a/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
+++ b/hwproj.front/src/components/Courses/Statistics/StudentStatsChart.tsx
@@ -12,6 +12,7 @@ import HelpPopoverChartInfo from './HelpPopoverChartInfo';
 import StudentCheckboxList from "./StudentCheckboxList";
 import StudentProgressChart from "./StudentProgressChart";
 import StudentPunctualityChart from './StudentPunctualityChart';
+import NameBuilder from "../../Utils/NameBuilder";
 
 interface IStudentStatsChartState {
     isFound: boolean;
@@ -132,7 +133,7 @@ const StudentStatsChart: React.FC = () => {
                         <Grid item container direction='column' xs={"auto"}>
                             <Grid item>
                                 <Typography style={{fontSize: '22px'}}>
-                                    {`${state.course.name} / ${state.course.groupName}`}
+                                    {NameBuilder.getCourseFullName(state.course.name!, state.course.groupName)}
                                     <sup style={{color: "#2979ff"}}> бета</sup>
                                 </Typography>
                             </Grid>

--- a/hwproj.front/src/components/Experts/AuthLayout.tsx
+++ b/hwproj.front/src/components/Experts/AuthLayout.tsx
@@ -56,17 +56,14 @@ const ExpertAuthLayout: FC<IExpertAuthLayoutProps> = (props: IExpertAuthLayoutPr
         ) : (
             <Center>
                 <Box sx={{minWidth: 150, marginTop: 15}}>
-                    <Paper elevation={3}>
-                        <Box p={2}>
-                            <Typography variant="h6" gutterBottom align="center">
-                                Отказано в доступе
-                            </Typography>
-                            <Typography variant="body1">
-                                Ссылка невалидна.
-                                Обратитесь к преподавателю для получения корректного приглашения в сервис.
-                            </Typography>
-                        </Box>
-                    </Paper>
+                    <Box p={2}>
+                        <Typography variant="h6" gutterBottom align="center">
+                            Ошибка в пригласительной ссылке
+                        </Typography>
+                        <Typography variant="body1">
+                            Ссылка просрочена или содержит опечатку. Обратитесь к выдавшему её преподавателю.
+                        </Typography>
+                    </Box>
                 </Box>
             </Center>
         )

--- a/hwproj.front/src/components/Experts/InviteModal.tsx
+++ b/hwproj.front/src/components/Experts/InviteModal.tsx
@@ -148,8 +148,6 @@ const InviteExpertModal: FC<IInviteExpertProps> = (props) => {
     return (
         <div>
             <Dialog open={props.isOpen} onClose={props.onClose} aria-labelledby="dialog-title" fullWidth>
-                <DialogTitle id="dialog-title">
-                    Пригласить эксперта
                 <DialogTitle id="dialog-title" style={{textAlign: "center"}}>
                     {props.expertFullName}
                 </DialogTitle>
@@ -191,7 +189,7 @@ const InviteExpertModal: FC<IInviteExpertProps> = (props) => {
                                                 }}>
                                                 {state.lecturerCourses.map((courseViewModel, i) =>
                                                     <MenuItem key={i} value={courseViewModel.id}>
-                                                        {courseViewModel.name}
+                                                        {NameBuilder.getCourseFullName(courseViewModel.name!, courseViewModel.groupName)}
                                                     </MenuItem>)}
                                             </Select>
                                         </FormControl>

--- a/hwproj.front/src/components/Experts/InviteModal.tsx
+++ b/hwproj.front/src/components/Experts/InviteModal.tsx
@@ -14,11 +14,13 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {CoursePreviewView, HomeworkViewModel, InviteExpertViewModel, AccountDataDto} from "../../api";
 import {Select, MenuItem, InputLabel, FormControl, Autocomplete} from "@mui/material";
 import CourseFilter from "../Courses/CourseFilter";
+import NameBuilder from "../Utils/NameBuilder";
 
 interface IInviteExpertProps {
     isOpen: boolean;
     onClose: any;
     expertEmail: string;
+    expertFullName: string;
     expertId: string;
 }
 
@@ -148,6 +150,8 @@ const InviteExpertModal: FC<IInviteExpertProps> = (props) => {
             <Dialog open={props.isOpen} onClose={props.onClose} aria-labelledby="dialog-title" fullWidth>
                 <DialogTitle id="dialog-title">
                     Пригласить эксперта
+                <DialogTitle id="dialog-title" style={{textAlign: "center"}}>
+                    {props.expertFullName}
                 </DialogTitle>
                 <DialogContent>
                     <Grid item container direction={"row"} justifyContent={"center"}>
@@ -163,7 +167,7 @@ const InviteExpertModal: FC<IInviteExpertProps> = (props) => {
                     ) : (
                         <div>
                             <Typography>
-                                Выберите курс:
+                                Выберите курс, на который хотите пригласить эксперта
                             </Typography>
                             <Grid container style={{marginTop: '10px'}}>
                                 <Grid container spacing={2}>

--- a/hwproj.front/src/components/Experts/Notebook.tsx
+++ b/hwproj.front/src/components/Experts/Notebook.tsx
@@ -8,7 +8,7 @@ import SpeedDialIcon from '@mui/material/SpeedDialIcon';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import {Typography, Grid, Button, Checkbox, FormControlLabel, CircularProgress} from "@material-ui/core";
+import {Typography, Grid, Button, Checkbox, FormControlLabel, CircularProgress, Snackbar} from "@material-ui/core";
 import {ExpertDataDTO, UpdateExpertTagsDTO} from 'api/api';
 import ApiSingleton from "../../api/ApiSingleton";
 import RegisterExpertModal from "./RegisterModal";
@@ -17,6 +17,7 @@ import Chip from "@mui/material/Chip/Chip";
 import InlineTags from "./InlineTags";
 import Tooltip from '@mui/material/Tooltip';
 import EditIcon from '@mui/icons-material/Edit';
+import {Alert} from "@mui/material";
 
 interface InviteExpertState {
     isOpen: boolean;
@@ -65,6 +66,7 @@ const ExpertsNotebook: FC = () => {
     const [mouseHoveredRow, setMouseHoveredRow] = useState<string>("");
     const [isAllExpertsSelected, setIsAllExpertsSelected] = useState<boolean>(false)
     const [isOpenRegisterExpert, setIsOpenRegisterExpert] = useState<boolean>(false)
+    const [expertWasRegistered, setExpertWasRegistered] = useState<boolean>(false)
 
     const [tagsEditingState, setTagsEditingState] = useState<EditTagsState>({
         isOpen: false,
@@ -110,7 +112,8 @@ const ExpertsNotebook: FC = () => {
         })
     }
 
-    const handleCloseExpertRegistration = () => {
+    const handleCloseExpertRegistration = (isExpertRegistered: boolean) => {
+        setExpertWasRegistered(isExpertRegistered)
         setIsOpenRegisterExpert(false);
     }
 
@@ -197,7 +200,7 @@ const ExpertsNotebook: FC = () => {
                         <Grid item style={{minHeight: 32}} alignContent={"center"}>
                             {mouseHoveredRow === expert.id &&
                                 <Button
-                                    onClick={() => handleOpenExpertInvitation(expert.email!, expert.id!)}
+                                    onClick={() => handleOpenExpertInvitation(expert)}
                                     color="primary"
                                     size="small"
                                 >
@@ -278,6 +281,18 @@ const ExpertsNotebook: FC = () => {
                 {inviteExpertState.isOpen && (
                     <InviteExpertModal isOpen={inviteExpertState.isOpen} onClose={handleCloseExpertInvitation}
                                        expertEmail={inviteExpertState.email} expertId={inviteExpertState.id}/>)}
+                                       expertEmail={inviteExpertState.email} expertId={inviteExpertState.id}
+                    />)}
+                <Snackbar
+                    anchorOrigin={{vertical: 'top', horizontal: 'center'}}
+                    open={expertWasRegistered}
+                    onClose={() => setExpertWasRegistered(false)}
+                    key={'top center'}
+                    autoHideDuration={5000}
+                    style={{marginTop: "40px"}}
+                >
+                    <Alert severity="success">Эксперт успешно зарегистрирован</Alert>
+                </Snackbar>
             </div>
         )
     }

--- a/hwproj.front/src/components/Experts/Notebook.tsx
+++ b/hwproj.front/src/components/Experts/Notebook.tsx
@@ -17,11 +17,13 @@ import Chip from "@mui/material/Chip/Chip";
 import InlineTags from "./InlineTags";
 import Tooltip from '@mui/material/Tooltip';
 import EditIcon from '@mui/icons-material/Edit';
+import NameBuilder from './../Utils/NameBuilder';
 import {Alert} from "@mui/material";
 
 interface InviteExpertState {
     isOpen: boolean;
     email: string;
+    fullName: string;
     id: string;
 }
 
@@ -76,6 +78,7 @@ const ExpertsNotebook: FC = () => {
     const [inviteExpertState, setInviteExpertState] = useState<InviteExpertState>({
         isOpen: false,
         email: "",
+        fullName: "",
         id: ""
     })
 
@@ -96,10 +99,11 @@ const ExpertsNotebook: FC = () => {
         setIsAllExpertsSelected(event.target.checked)
     };
 
-    const handleOpenExpertInvitation = (expertEmail: string, expertId: string) => {
+    const handleOpenExpertInvitation = (expert: ExpertDataDTO) => {
         setInviteExpertState({
-            email: expertEmail,
-            id: expertId,
+            email: expert.email!,
+            fullName: NameBuilder.getUserFullName(expert.name, expert.surname, expert.middleName),
+            id: expert.id!,
             isOpen: true
         })
     }
@@ -107,6 +111,7 @@ const ExpertsNotebook: FC = () => {
     const handleCloseExpertInvitation = () => {
         setInviteExpertState({
             email: "",
+            fullName: "",
             id: "",
             isOpen: false
         })
@@ -156,8 +161,8 @@ const ExpertsNotebook: FC = () => {
                 key={expert.id}
                 onMouseEnter={() => setMouseHoveredRow(expert.id!)}
             >
-                <TableCell
-                    align={"left"}>{expert.surname + ' ' + expert.name + ' ' + expert.middleName}
+                <TableCell align={"left"} sx={{ fontWeight: 500 }}>
+                    {NameBuilder.getUserFullName(expert.name, expert.surname, expert.middleName)}
                     {isExpertControlled(expert.lecturerId!) && <ControlledExpertTip/>}
                 </TableCell>
                 <TableCell align={"center"}>{expert.email}</TableCell>
@@ -280,8 +285,8 @@ const ExpertsNotebook: FC = () => {
                     <RegisterExpertModal isOpen={isOpenRegisterExpert} onClose={handleCloseExpertRegistration}/>)}
                 {inviteExpertState.isOpen && (
                     <InviteExpertModal isOpen={inviteExpertState.isOpen} onClose={handleCloseExpertInvitation}
-                                       expertEmail={inviteExpertState.email} expertId={inviteExpertState.id}/>)}
                                        expertEmail={inviteExpertState.email} expertId={inviteExpertState.id}
+                                       expertFullName={inviteExpertState.fullName}
                     />)}
                 <Snackbar
                     anchorOrigin={{vertical: 'top', horizontal: 'center'}}

--- a/hwproj.front/src/components/Experts/RegisterModal.tsx
+++ b/hwproj.front/src/components/Experts/RegisterModal.tsx
@@ -15,12 +15,11 @@ import ValidationUtils from "../Utils/ValidationUtils";
 
 interface IRegisterExpertProps {
     isOpen: boolean;
-    onClose: any;
+    onClose: (isExpertRegistered: boolean) => void;
 }
 
 interface IRegisterExpertState {
     errors: string[];
-    isRegisterSuccessful: boolean | undefined;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -57,7 +56,6 @@ const RegisterExpertModal: FC<IRegisterExpertProps> = (props) => {
 
     const [commonState, setCommonState] = useState<IRegisterExpertState>({
         errors: [],
-        isRegisterSuccessful: undefined
     })
 
 
@@ -82,9 +80,11 @@ const RegisterExpertModal: FC<IRegisterExpertProps> = (props) => {
             setCommonState((prevState) => ({
                 ...prevState,
                 errors: result!.errors ?? [],
-                isRegisterSuccessful: result.succeeded
             }));
-            handleClose();
+
+            if (result.succeeded) {
+                handleClose(result.succeeded!);
+            }
         } catch (e) {
             setCommonState((prevState) => ({
                 ...prevState,
@@ -93,7 +93,7 @@ const RegisterExpertModal: FC<IRegisterExpertProps> = (props) => {
         }
     }
 
-    const handleClose = () => {
+    const handleClose = (isExpertRegistered: boolean) => {
         setRegisterState({
             name: "",
             surname: "",
@@ -102,11 +102,8 @@ const RegisterExpertModal: FC<IRegisterExpertProps> = (props) => {
             companyName: "",
             bio: ""
         })
-        setCommonState(prevState => ({
-            ...prevState,
-            isRegisterSuccessful: undefined
-        }))
-        props.onClose()
+
+        props.onClose(isExpertRegistered)
     }
 
     return (
@@ -130,9 +127,6 @@ const RegisterExpertModal: FC<IRegisterExpertProps> = (props) => {
                     <Grid item container direction={"row"} justifyContent={"center"}>
                         {commonState.errors.length > 0 && (
                             <p style={{color: "red", marginBottom: "0"}}>{commonState.errors}</p>
-                        )}
-                        {commonState.isRegisterSuccessful && (
-                            <p style={{color: "green", marginBottom: "0"}}>Эксперт успешно зарегистрирован</p>
                         )}
                     </Grid>
                     <form onSubmit={handleSubmit} className={classes.form}>
@@ -250,7 +244,7 @@ const RegisterExpertModal: FC<IRegisterExpertProps> = (props) => {
                         >
                             <Grid item>
                                 <Button
-                                    onClick={handleClose}
+                                    onClick={() => handleClose(false)}
                                     color="primary"
                                     variant="contained"
                                     style={{marginRight: '10px'}}

--- a/hwproj.front/src/components/Utils/NameBuilder.tsx
+++ b/hwproj.front/src/components/Utils/NameBuilder.tsx
@@ -1,0 +1,18 @@
+﻿export default class NameBuilder {
+    static getUserFullName(
+        name: string | undefined,
+        surname: string | undefined,
+        middleName: string | undefined
+    ) {
+        return [surname, name, middleName]
+            .filter(Boolean)
+            .join(' ');
+    }
+
+    static getCourseFullName(
+        courseName: string,
+        groupName: string | undefined,
+    ) {
+        return courseName + (groupName?.length != 0 ? " / " + groupName : "")
+    }
+}

--- a/hwproj.front/src/services/AuthService.ts
+++ b/hwproj.front/src/services/AuthService.ts
@@ -61,8 +61,7 @@ export default class AuthService {
             let decoded = decode<TokenPayload>(token);
             return decoded.exp < Date.now() / 1000;
         } catch (err) {
-
-            return false;
+            return true;
         }
     }
 


### PR DESCRIPTION
Исправлены следующие замечания из #421
- В модальном окне приглашения эксперта указываем его ФИО, а также указываем номер группы рядом с названием курса. 
<p align="center">
  <img width="400" src="https://github.com/user-attachments/assets/a6175588-04a6-4f21-a645-c0a2a099d653">
</p>

- Исправлена ошибка отображения невалидного токена (теперь на экран выводится элемент со скриншота ниже)
<p align="center">
  <img width="600" src="https://github.com/user-attachments/assets/72e5c329-d47b-4217-94b1-4b975c0c6ea1">
</p>

- ФИО экспертов в "записной книжке" стали пожирнее
<p align="center">
  <img width="600" src="https://github.com/user-attachments/assets/70fbd4f4-bd76-4b3d-8b8f-831783d4b904">
</p>

- В окне регистрации эксперта при неудачной регистрации выводится ошибка, сам элемент не закрывается.
<p align="center">
  <img width="200" src="https://github.com/user-attachments/assets/e8d75a3b-589d-40f5-bd6b-58e99309d811">
</p>

- В случае удачной регистрации элемент закрывается, на экран падает уведомление
<p align="center">
  <img width="600" src="https://github.com/user-attachments/assets/57ccdeb1-4f55-4a99-a6cc-eae93e7e100a">
</p>