### PR TITLE
Обновление редактора Markdown в сервисе

### DIFF
--- a/hwproj.front/package.json
+++ b/hwproj.front/package.json
@@ -22,6 +22,8 @@
     "@types/recharts": "^1.8.29",
     "@types/remarkable": "^1.7.4",
     "@types/request": "^2.48.7",
+    "@uiw/react-markdown-preview": "4.2.2",
+    "@uiw/react-md-editor": "3.25.6",
     "axios": "^0.28.0",
     "bootstrap": "^4.3.1",
     "classnames": "^2.3.1",
@@ -45,7 +47,8 @@
     "react-scripts": "^4.0.3",
     "react-social-login-buttons": "^3.5.1",
     "react-syntax-highlighter": "^15.5.0",
-    "recharts": "^2.12.3"
+    "recharts": "^2.12.3",
+    "rehype-sanitize": "^6.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/hwproj.front/src/components/Common/MarkdownEditor.tsx
+++ b/hwproj.front/src/components/Common/MarkdownEditor.tsx
@@ -1,0 +1,73 @@
+﻿import {ChangeEvent, FC} from "react";
+import MDEditor from "@uiw/react-md-editor";
+import { getCommands, getExtraCommands } from "./Styles/MarkdownEditorCommands.ru";
+import rehypeSanitize from "rehype-sanitize";
+import * as React from "react";
+
+import "@uiw/react-md-editor/markdown-editor.css";
+import "@uiw/react-markdown-preview/markdown.css";
+import "./Styles/MarkdownEditor.css";
+
+interface MarkdownEditorProps {
+    label: string;
+    maxHeight?: number;
+    height?: number;
+    value: string;
+    onChange: (value: string) => void;
+}
+
+interface MarkdownPreviewProps {
+    value: string;
+    backgroundColor?: string;
+    textColor?: string;
+}
+
+const MarkdownPreview: FC<MarkdownPreviewProps> = (props) =>
+    <MDEditor.Markdown
+        className="markdown-preview"
+        source={props.value}
+        style={{
+            backgroundColor: props.backgroundColor ?? "transparent",
+            color: props.textColor ?? "inherit",
+            paddingBottom: '15px'
+        }}
+        wrapperElement={{
+            "data-color-mode": "light"
+        }}
+    />
+
+const MarkdownEditor: FC<MarkdownEditorProps> = (props) => {
+    const handleChange = (value: string | undefined, event?: ChangeEvent<HTMLTextAreaElement>) => {
+        if (value !== undefined) {
+            props.onChange(value!);
+        }
+    };
+
+    return (
+        <div
+            data-color-mode="light"
+            style={{
+                marginTop: '15px',
+                marginBottom: '15px',
+            }}
+        >
+            <MDEditor
+                commands={[...getCommands()]}
+                extraCommands={[...getExtraCommands()]}
+                value={props.value}
+                onChange={handleChange}
+                previewOptions={{
+                    rehypePlugins: [[rehypeSanitize]],
+                    className: "markdown-preview"
+                }}
+                maxHeight={props.maxHeight ?? 400}
+                height={props.height ?? 200}
+                textareaProps={{
+                    placeholder: props.label
+                }}
+            />
+        </div>
+    );
+}
+
+export {MarkdownEditor, MarkdownPreview}

--- a/hwproj.front/src/components/Common/Styles/MarkdownEditor.css
+++ b/hwproj.front/src/components/Common/Styles/MarkdownEditor.css
@@ -1,0 +1,13 @@
+﻿.w-md-editor-text-pre > code,
+.w-md-editor-text-input {
+    font-size: 16px !important;
+    line-height: 19px !important;
+}
+
+.markdown-preview{
+    font-size: 1rem;
+    font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+    font-weight: 400;
+    line-height: 1.5;
+    letter-spacing: 0.00938em;
+}

--- a/hwproj.front/src/components/Common/Styles/MarkdownEditorCommands.ru.ts
+++ b/hwproj.front/src/components/Common/Styles/MarkdownEditorCommands.ru.ts
@@ -1,0 +1,205 @@
+﻿import {ICommand} from '@uiw/react-md-editor/esm/commands';
+import {
+    divider,
+    group,
+    code as codeInit,
+    codeBlock as codeBlockInit,
+    comment as commentInit,
+    fullscreen as fullscreenInit,
+    hr as hrInit,
+    image as imageInit,
+    italic as italicInit,
+    bold as boldInit,
+    link as linkInit,
+    checkedListCommand as checkedListCommandInit,
+    orderedListCommand as orderedListCommandInit,
+    unorderedListCommand as unorderedListCommandInit,
+    codeEdit as codeEditInit,
+    codeLive as codeLiveInit,
+    codePreview as codePreviewInit,
+    quote as quoteInit,
+    strikethrough as strikethroughInit,
+    issue as issueInit,
+    title as titleInit,
+    title1 as title1Init,
+    title2 as title2Init,
+    title3 as title3Init,
+    title4 as title4Init,
+    title5 as title5Init,
+    title6 as title6Init,
+    table as tableInit,
+    help as helpInit
+} from '@uiw/react-md-editor/esm/commands';
+
+let bold: ICommand = {
+    ...boldInit,
+    buttonProps: {'aria-label': 'Выделить жирным (ctrl + b)', title: 'Выделить жирным (ctrl + b)'},
+};
+let code: ICommand = {
+    ...codeInit,
+    buttonProps: {'aria-label': 'Вставить код (ctrl + j)', title: 'Вставить код (ctrl + j)'}
+};
+let codeBlock: ICommand = {
+    ...codeBlockInit,
+    buttonProps: {
+        'aria-label': 'Вставить блок кода (ctrl + shift + j)',
+        title: 'Вставить блок кода (ctrl + shift + j)'
+    },
+};
+let comment: ICommand = {
+    ...commentInit,
+    buttonProps: {'aria-label': 'Закомментировать (ctrl + /)', title: 'Закомментировать (ctrl + /)'},
+};
+let fullscreen: ICommand = {
+    ...fullscreenInit,
+    buttonProps: {'aria-label': 'На весь экран (ctrl + 0)', title: 'На весь экран (ctrl + 0)'},
+};
+let hr: ICommand = {
+    ...hrInit, buttonProps: {
+        'aria-label': 'Вставить горизонтальную линию (ctrl + h)',
+        title: 'Вставить горизонтальную линию (ctrl + h)'
+    }
+};
+let image: ICommand = {
+    ...imageInit,
+    buttonProps: {'aria-label': 'Добавить изображение (ctrl + k)', title: 'Добавить изображение (ctrl + k)'},
+};
+let italic: ICommand = {
+    ...italicInit,
+    buttonProps: {'aria-label': 'Выделить курсивом (ctrl + i)', title: 'Выделить курсивом (ctrl + i)'},
+};
+let link: ICommand = {
+    ...linkInit,
+    buttonProps: {'aria-label': 'Добавить ссылку (ctrl + l)', title: 'Добавить ссылку (ctrl + l)'}
+};
+let checkedListCommand: ICommand = {
+    ...checkedListCommandInit,
+    buttonProps: {'aria-label': 'Добавить список (ctrl + shift + c)', title: 'Добавить список (ctrl + shift + c)'},
+};
+let orderedListCommand: ICommand = {
+    ...orderedListCommandInit,
+    buttonProps: {
+        'aria-label': 'Добавить нумерованный список (ctrl + shift + o)',
+        title: 'Добавить нумерованный список (ctrl + shift + o)'
+    },
+};
+let unorderedListCommand: ICommand = {
+    ...unorderedListCommandInit,
+    buttonProps: {
+        'aria-label': 'Добавить маркированный список (ctrl + shift + u)',
+        title: 'Добавить маркированный список (ctrl + shift + u)',
+    },
+};
+let codeEdit: ICommand = {
+    ...codeEditInit,
+    buttonProps: {'aria-label': 'В режим редактирования (ctrl + 7)', title: 'В режим редактирования (ctrl + 7)'},
+};
+let codeLive: ICommand = {
+    ...codeLiveInit,
+    buttonProps: {'aria-label': 'В дублированный режим (ctrl + 8)', title: 'В дублированный режим (ctrl + 8)'},
+};
+let codePreview: ICommand = {
+    ...codePreviewInit,
+    buttonProps: {'aria-label': 'В режим превью (ctrl + 9)', title: 'В режим превью (ctrl + 9)'},
+};
+let quote: ICommand = {
+    ...quoteInit,
+    buttonProps: {'aria-label': 'Вставить цитату (ctrl + 9)', title: 'Вставить цитату (ctrl + 9)'},
+};
+let strikethrough: ICommand = {
+    ...strikethroughInit,
+    buttonProps: {
+        'aria-label': 'Выделить зачеркнутым (ctrl + shift + x)',
+        title: 'Выделить зачеркнутым (ctrl + shift + x)',
+    },
+};
+let title: ICommand = {
+    ...titleInit,
+    buttonProps: {'aria-label': 'Вставить заголовок (ctrl + 1)', title: 'Вставить заголовок (ctrl + 1)'},
+};
+let title1: ICommand = {
+    ...title1Init,
+    buttonProps: {'aria-label': 'Вставить заголовок 1 (ctrl + 1)', title: 'Вставить заголовок 1 (ctrl + 1)'},
+};
+let title2: ICommand = {
+    ...title2Init,
+    buttonProps: {'aria-label': 'Вставить заголовок 2 (ctrl + 2)', title: 'Вставить заголовок 2 (ctrl + 2)'},
+};
+let title3: ICommand = {
+    ...title3Init,
+    buttonProps: {'aria-label': 'Вставить заголовок 3 (ctrl + 3)', title: 'Вставить заголовок 3 (ctrl + 3)'},
+};
+let title4: ICommand = {
+    ...title4Init,
+    buttonProps: {'aria-label': 'Вставить заголовок 4 (ctrl + 4)', title: 'Вставить заголовок 4 (ctrl + 4)'},
+};
+let title5: ICommand = {
+    ...title5Init,
+    buttonProps: {'aria-label': 'Вставить заголовок 5 (ctrl + 5)', title: 'Вставить заголовок 5 (ctrl + 5)'},
+};
+let title6: ICommand = {
+    ...title6Init,
+    buttonProps: {'aria-label': 'Вставить заголовок 6 (ctrl + 6)', title: 'Вставить заголовок 6 (ctrl + 6)'},
+};
+let table: ICommand = {...tableInit, buttonProps: {'aria-label': 'Добавить таблицу', title: 'Добавить таблицу'}};
+let help: ICommand = {
+    ...helpInit,
+    buttonProps: {'aria-label': 'Открыть описание Markdown', title: 'Открыть описание Markdown'}
+};
+
+export const getCommands: () => ICommand[] = () => [
+    bold,
+    italic,
+    strikethrough,
+    hr,
+    group([title1, title2, title3, title4, title5, title6], {
+        name: 'title',
+        groupName: 'title',
+        buttonProps: {'aria-label': 'Вставить заголовок', title: 'Вставить заголовок'},
+    }),
+    divider,
+    link,
+    quote,
+    code,
+    codeBlock,
+    comment,
+    image,
+    table,
+    divider,
+    unorderedListCommand,
+    orderedListCommand,
+    checkedListCommand,
+    divider,
+    help,
+];
+export const getExtraCommands: () => ICommand[] = () => [codeEdit, codeLive, codePreview, divider, fullscreen];
+export {
+    title,
+    title1,
+    title2,
+    title3,
+    title4,
+    title5,
+    title6,
+    bold,
+    codeBlock,
+    comment,
+    italic,
+    strikethrough,
+    hr,
+    group,
+    divider,
+    link,
+    quote,
+    code,
+    image,
+    unorderedListCommand,
+    orderedListCommand,
+    checkedListCommand,
+    table,
+    help,
+    codeEdit,
+    codeLive,
+    codePreview,
+    fullscreen,
+};

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -20,8 +20,8 @@ import {Card, CardActions, CardContent, Chip, Divider, Paper, Stack, Tooltip} fr
 import {Link} from "react-router-dom";
 import StudentStatsUtils from "../../services/StudentStatsUtils";
 import Utils from "../../services/Utils";
-import {ReactMarkdownWithCodeHighlighting} from "../Common/TextFieldWithPreview";
 import {getTip} from "../Common/HomeworkTags";
+import {MarkdownPreview} from "../Common/MarkdownEditor";
 
 interface ICourseExperimentalProps {
     homeworks: HomeworkViewModel[]
@@ -97,7 +97,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
             </Grid>
             <Divider style={{marginTop: 15, marginBottom: 15}}/>
             <Typography style={{color: "#454545"}} gutterBottom variant="body1">
-                <ReactMarkdownWithCodeHighlighting value={homework.description!}/>
+                <MarkdownPreview value={homework.description!}/>
             </Typography>
         </CardContent>
     }
@@ -119,7 +119,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
             </Grid>
             <Divider style={{marginTop: 15, marginBottom: 15}}/>
             <Typography style={{color: "#454545"}} gutterBottom variant="body1">
-                <ReactMarkdownWithCodeHighlighting value={task.description!}/>
+                <MarkdownPreview value={task.description!}/>
             </Typography>
         </CardContent>
     }

--- a/hwproj.front/src/components/Homeworks/AddHomework.tsx
+++ b/hwproj.front/src/components/Homeworks/AddHomework.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import ApiSingleton from "../../api/ApiSingleton";
 import {useEffect, useState} from "react";
 import {Grid, TextField, Button, Typography} from "@material-ui/core";
-import {TextFieldWithPreview} from "../Common/TextFieldWithPreview";
+import {MarkdownEditor} from "../Common/MarkdownEditor";
 import {CreateHomeworkViewModel, CreateTaskViewModel, HomeworkViewModel} from "../../api";
 import PublicationAndDeadlineDates from "../Common/PublicationAndDeadlineDates";
 import CreateTask from "../Tasks/CreateTask"
@@ -141,24 +141,18 @@ const AddHomework: React.FC<IAddHomeworkProps> = (props) => {
                     }
                     }
                 />
-                <TextFieldWithPreview
-                    multiline
-                    fullWidth
-                    minRows={4}
-                    maxRows="20"
-                    label="Описание"
-                    variant="outlined"
-                    margin="normal"
-                    value={addHomeworkState.description}
-                    onChange={(e) => {
-                        e.persist()
-                        setAddHomeworkState((prevState) => ({
-                            ...prevState,
-                            description: e.target.value
-                        }))
-                    }
-                    }
-                />
+                <div style={{ marginBottom: -3, marginTop: -5 }}>
+                    <MarkdownEditor
+                        label={"Описание"}
+                        value={addHomeworkState.description}
+                        onChange={(value) => {
+                            setAddHomeworkState((prevState) => ({
+                                ...prevState,
+                                description: value
+                            }))
+                        }}
+                    />
+                </div>
                 <Tags tags={[]} onTagsChange={handleTagsChange} isElementSmall={false}
                       requestTags={() => apiSingleton.coursesApi.apiCoursesTagsByCourseIdGet(props.id)}/>
                 {addHomeworkState.tags.includes(TestTag) &&

--- a/hwproj.front/src/components/Homeworks/EditHomework.tsx
+++ b/hwproj.front/src/components/Homeworks/EditHomework.tsx
@@ -5,7 +5,7 @@ import {FC, useEffect, useState} from "react";
 import {makeStyles} from "@material-ui/styles";
 import EditIcon from '@material-ui/icons/Edit';
 import {Button} from "@material-ui/core";
-import {TextFieldWithPreview} from "../Common/TextFieldWithPreview";
+import {MarkdownEditor} from "../Common/MarkdownEditor";
 import PublicationAndDeadlineDates from "../Common/PublicationAndDeadlineDates";
 import Tags from "../Common/Tags";
 import {Grid, Typography, TextField} from "@mui/material";
@@ -178,21 +178,16 @@ const EditHomework: FC = () => {
                                 }}
                             />
                         </Grid>
-                        <Grid item xs={12} style={{marginBottom: "10px"}}>
-                            <TextFieldWithPreview
-                                multiline
-                                fullWidth
-                                minRows={7}
-                                maxRows="20"
-                                label="Условие задания"
-                                variant="outlined"
-                                margin="normal"
+                        <Grid item xs={12} style={{marginBottom: "5px", marginTop: -2}}>
+                            <MarkdownEditor
+                                label={"Условие задания"}
+                                height={240}
+                                maxHeight={400}
                                 value={editHomework.description}
-                                onChange={(e) => {
-                                    e.persist()
+                                onChange={(value) => {
                                     setEditHomework((prevState) => ({
                                         ...prevState,
-                                        description: e.target.value
+                                        description: value
                                     }))
                                 }}
                             />

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -21,8 +21,8 @@ import {
     Tooltip
 } from '@material-ui/core';
 import {Stack} from '@mui/material';
-import {ReactMarkdownWithCodeHighlighting} from "../Common/TextFieldWithPreview";
 import Utils from "../../services/Utils";
+import {MarkdownPreview} from "../Common/MarkdownEditor";
 
 interface IHomeworkProps {
     homework: HomeworkViewModel,
@@ -115,7 +115,7 @@ const Homework: FC<IHomeworkProps> = (props) => {
                 </AccordionSummary>
                 <AccordionDetails>
                     <div style={{width: '100%'}}>
-                        <ReactMarkdownWithCodeHighlighting value={props.homework.description!}/>
+                        <MarkdownPreview value={props.homework.description!}/>
                         {(props.forMentor && homeworkState.createTask) &&
                             <div style={{width: '100%'}}>
                                 <HomeworkTasks

--- a/hwproj.front/src/components/Solutions/AddOrEditSolution.tsx
+++ b/hwproj.front/src/components/Solutions/AddOrEditSolution.tsx
@@ -5,7 +5,7 @@ import ApiSingleton from "../../api/ApiSingleton";
 import {AccountDataDto, GetSolutionModel, HomeworkTaskViewModel, Solution, SolutionViewModel} from "../../api";
 import {FC, useState} from "react";
 import {Alert, Autocomplete, Grid, DialogContent, Dialog, DialogTitle, DialogActions} from "@mui/material";
-import {TextFieldWithPreview} from "../Common/TextFieldWithPreview";
+import {MarkdownEditor} from "../Common/MarkdownEditor";
 import {TestTag} from "../Common/HomeworkTags";
 
 interface IAddSolutionProps {
@@ -101,22 +101,14 @@ const AddOrEditSolution: FC<IAddSolutionProps> = (props) => {
                                 взята из предыдущего
                                 решения</Alert>}
                     </Grid>}
-                    <Grid item xs={12} style={{marginTop: '16px'}}>
-                        <TextFieldWithPreview
-                            multiline
-                            fullWidth
-                            minRows={4}
-                            maxRows={20}
-                            margin="normal"
-                            label="Комментарий"
-                            variant="outlined"
-                            previewStyle={{borderColor: "GrayText"}}
-                            value={solution.comment}
-                            onChange={(e) => {
-                                e.persist()
+                    <Grid item xs={12} style={{marginTop: '12px', marginBottom: -4}}>
+                        <MarkdownEditor
+                            label={"Комментарий"}
+                            value={solution.comment ?? ""}
+                            onChange={(value) => {
                                 setSolution((prevState) => ({
                                     ...prevState,
-                                    comment: e.target.value,
+                                    comment: value
                                 }))
                             }}
                         />

--- a/hwproj.front/src/components/Solutions/TaskSolutionComponent.tsx
+++ b/hwproj.front/src/components/Solutions/TaskSolutionComponent.tsx
@@ -17,7 +17,7 @@ import AvatarUtils from "../Utils/AvatarUtils";
 import Utils from "../../services/Utils";
 import {RatingStorage} from "../Storages/RatingStorage";
 import {Edit, ThumbDown, ThumbUp} from "@mui/icons-material";
-import {ReactMarkdownWithCodeHighlighting, TextFieldWithPreview} from "../Common/TextFieldWithPreview";
+import {MarkdownEditor, MarkdownPreview} from "../Common/MarkdownEditor";
 import {LoadingButton} from "@mui/lab";
 import CheckIcon from '@mui/icons-material/Done';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -307,40 +307,25 @@ const TaskSolutionComponent: FC<ISolutionProps> = (props) => {
                             </Stack>
                         </Grid>}
                     {state.clickedForRate
-                        ? <Grid item>
-                            <TextFieldWithPreview
-                                multiline
-                                fullWidth
-                                InputProps={{
-                                    readOnly: !props.forMentor || !state.clickedForRate
-                                }}
-                                rows="4"
-                                rowsMax="15"
+                        ? <Grid item style={{marginBottom: -7, marginTop: -8}}>
+                            <MarkdownEditor
                                 label="Комментарий преподавателя"
-                                variant="outlined"
-                                margin="normal"
-                                isEditable={props.forMentor}
                                 value={state.lecturerComment}
-                                previewStyle={{borderColor: undefined}}
-                                onClick={() => {
-                                    if (!state.clickedForRate)
-                                        setState((prevState) => ({
-                                            ...prevState,
-                                            clickedForRate: true
-                                        }))
-                                }}
-                                onChange={(e) => {
-                                    e.persist()
+                                onChange={(value) => {
                                     setState((prevState) => ({
                                         ...prevState,
-                                        lecturerComment: e.target.value
+                                        lecturerComment: value
                                     }))
                                 }}
                             />
-                        </Grid>
+                       </Grid>
                         : isRated &&
                         <Grid item>
-                            <ReactMarkdownWithCodeHighlighting value={lecturerComment}/>
+                            <MarkdownPreview
+                                value={lecturerComment} 
+                                backgroundColor={backgroundColor}
+                                textColor={color}
+                            />
                         </Grid>
                     }
                 </Grid>
@@ -430,7 +415,7 @@ const TaskSolutionComponent: FC<ISolutionProps> = (props) => {
                 </Grid>
                 {solution.comment &&
                     <Grid item style={{marginBottom: -16}}>
-                        <ReactMarkdownWithCodeHighlighting value={solution.comment as string}/>
+                        <MarkdownPreview value={solution.comment}/>
                     </Grid>
                 }
             </Grid>

--- a/hwproj.front/src/components/Tasks/CreateTask.tsx
+++ b/hwproj.front/src/components/Tasks/CreateTask.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import {FC, useEffect, useState} from "react";
 import {Grid, TextField} from "@material-ui/core";
-import {TextFieldWithPreview} from "../Common/TextFieldWithPreview";
 import TaskPublicationAndDeadlineDates from "../Common/TaskPublicationAndDeadlineDates";
 import {HomeworkViewModel} from 'api';
+import {MarkdownEditor} from "../Common/MarkdownEditor";
 
 interface ICreateTaskProps {
     homework: HomeworkViewModel;
@@ -72,24 +72,20 @@ const CreateTask: FC<ICreateTaskProps> = (props) => {
                     }}
                 />
             </Grid>
-            <TextFieldWithPreview
-                multiline
-                fullWidth
-                minRows={7}
-                maxRows="20"
-                label="Условие задачи"
-                variant="outlined"
-                margin="normal"
-                value={createTaskState.description}
-                onChange={(e) => {
-                    e.persist()
-                    setCreateTaskState((prevState) => ({
-                        ...prevState,
-                        description: e.target.value,
-                    }))
-                }}
-            />
-
+            <div style={{marginBottom: -3, marginTop: -5}}>
+                <MarkdownEditor
+                    label={"Условие задачи"}
+                    height={240}
+                    maxHeight={400}
+                    value={createTaskState.description}
+                    onChange={(value) => {
+                        setCreateTaskState((prevState) => ({
+                            ...prevState,
+                            description: value,
+                        }))
+                    }}
+                />
+            </div>
             <TaskPublicationAndDeadlineDates
                 hasDeadline={undefined}
                 isDeadlineStrict={undefined}

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -6,7 +6,7 @@ import EditIcon from "@material-ui/icons/Edit";
 import {makeStyles} from "@material-ui/styles";
 import {Button} from "@material-ui/core";
 import {Typography, TextField, Grid} from "@mui/material";
-import {TextFieldWithPreview} from "../Common/TextFieldWithPreview";
+import {MarkdownEditor} from "../Common/MarkdownEditor";
 import TaskPublicationAndDeadlineDates from "../Common/TaskPublicationAndDeadlineDates";
 import {HomeworkViewModel} from "../../api";
 
@@ -190,21 +190,16 @@ const EditTask: FC = () => {
                                         />
                                     </Grid>
                                 </Grid>
-                                <Grid item xs={12}>
-                                    <TextFieldWithPreview
-                                        multiline
-                                        fullWidth
-                                        minRows={7}
-                                        maxRows="20"
-                                        label="Условие задачи"
-                                        variant="outlined"
-                                        margin="normal"
+                                <Grid item xs={12} marginBottom={-1} marginTop={-1}>
+                                    <MarkdownEditor
+                                        label={"Условие задачи"}
+                                        height={240}
+                                        maxHeight={400}
                                         value={taskState.description}
-                                        onChange={(e) => {
-                                            e.persist()
+                                        onChange={(value) => {
                                             setTaskState((prevState) => ({
                                                 ...prevState,
-                                                description: e.target.value
+                                                description: value
                                             }))
                                         }}
                                     />

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -12,10 +12,10 @@ import {FC, useState} from "react";
 import {makeStyles} from "@material-ui/styles";
 import DeletionConfirmation from "../DeletionConfirmation";
 import {Chip, Stack} from "@mui/material";
-import {ReactMarkdownWithCodeHighlighting} from "../Common/TextFieldWithPreview";
 import Utils from "../../services/Utils";
 import {getTip} from "../Common/HomeworkTags";
 import StarIcon from '@mui/icons-material/Star';
+import {MarkdownPreview} from "../Common/MarkdownEditor";
 
 interface ITaskProp {
     task: HomeworkTaskViewModel,
@@ -116,9 +116,9 @@ const Task: FC<ITaskProp> = (props) => {
                     </div>
                 </AccordionSummary>
                 <AccordionDetails>
-                    <Grid>
+                    <Grid style={{width: "100%"}}>
                         <Typography variant="body1">
-                            <ReactMarkdownWithCodeHighlighting value={task.description!}/>
+                            <MarkdownPreview value={task.description!}/>
                         </Typography>
                         {props.showForCourse && props.forStudent &&
                             <div style={{marginTop: '15px'}}>

--- a/hwproj.front/src/components/Tasks/TaskQuestions.tsx
+++ b/hwproj.front/src/components/Tasks/TaskQuestions.tsx
@@ -11,7 +11,7 @@ import {
     Typography
 } from "@mui/material";
 import * as React from "react";
-import {ReactMarkdownWithCodeHighlighting, TextFieldWithPreview} from "../Common/TextFieldWithPreview";
+import {MarkdownEditor, MarkdownPreview} from "../Common/MarkdownEditor";
 import Button from "@material-ui/core/Button";
 import ApiSingleton from "../../api/ApiSingleton";
 import {AccountDataDto, AddAnswerForQuestionDto, AddTaskQuestionDto, GetTaskQuestionDto} from "../../api";
@@ -83,25 +83,18 @@ const TaskQuestions: FC<ITaskQuestionsProps> = (props) => {
                         />
                     }
                 />
-                <TextFieldWithPreview
-                    multiline
-                    fullWidth
-                    style={{width: "100%", minWidth: "100%"}}
-                    minRows={4}
-                    maxRows={20}
-                    margin="normal"
-                    label="Вопрос"
-                    variant="outlined"
-                    previewStyle={{borderColor: "GrayText"}}
-                    value={addQuestionState.text}
-                    onChange={(e) => {
-                        e.persist()
-                        setAddQuestionState((prevState) => ({
-                            ...prevState,
-                            text: e.target.value,
-                        }))
-                    }}
-                />
+                <div style={{marginTop: -2, marginBottom: -4}}>
+                    <MarkdownEditor
+                        label={"Вопрос"}
+                        value={addQuestionState.text ?? ""}
+                        onChange={(value) => {
+                            setAddQuestionState((prevState) => ({
+                                ...prevState,
+                                text: value
+                            }))
+                        }}
+                    />
+                </div>
             </DialogContent>
             <DialogActions>
                 <Button
@@ -176,26 +169,19 @@ const TaskQuestions: FC<ITaskQuestionsProps> = (props) => {
                         {isCurrentStudent && <Typography variant={"caption"}>
                             Вопрос от проверяемого студента:
                         </Typography>}
-                        <ReactMarkdownWithCodeHighlighting value={q.text!}/>
-                        {!isAnswered && q.id === addAnswerState.questionId && <TextFieldWithPreview
-                            multiline
-                            fullWidth
-                            style={{width: "100%"}}
-                            minRows={4}
-                            maxRows={20}
-                            margin="normal"
-                            label="Ответ"
-                            variant="outlined"
-                            previewStyle={{borderColor: "GrayText"}}
-                            value={addAnswerState.answer}
-                            onChange={(e) => {
-                                e.persist()
-                                setAddAnswerState((prevState) => ({
-                                    ...prevState,
-                                    answer: e.target.value,
-                                }))
-                            }}
-                        />}
+                        <MarkdownPreview value={q.text!} backgroundColor={"transparent"} textColor={"inherit"}/>
+                        {!isAnswered && q.id === addAnswerState.questionId &&
+                            <MarkdownEditor
+                                label={"Ответ"}
+                                value={addAnswerState.answer ?? ""}
+                                onChange={(value) => {
+                                    setAddAnswerState((prevState) => ({
+                                        ...prevState,
+                                        answer: value
+                                    }))
+                                }}
+                            />
+                        }
                         {isAnswered &&
                             <div>
                                 <Typography variant={"caption"}>
@@ -204,7 +190,7 @@ const TaskQuestions: FC<ITaskQuestionsProps> = (props) => {
                                 <Card variant={"outlined"}
                                       style={{backgroundColor: "ghostwhite"}}>
                                     <CardContent style={{paddingBottom: 0, marginBottom: 0}}>
-                                        <ReactMarkdownWithCodeHighlighting value={q.answer!}/>
+                                        <MarkdownPreview value={q.answer!}/>
                                     </CardContent>
                                 </Card>
                             </div>}


### PR DESCRIPTION
**Обновлён редактор Markdown** во всех местах использования: комментирование решения со стороны преподавателя и студента, создание, редактирование задач и домашних работ, создание вопросов и ответов. Также в соответствующих местах обновлен компонент markdown-preview, отвечающий за рендеринг markdown.
- В новом редакторе также реализовал локализацию вспомогательного текста (появляется при наведении на кнопки тулбара), подключил в качестве плагина rehype-sanitize для защиты от XSS.

- Сохранены стили предыдущей версии preview сервиса: шрифт, размер и т.д. Для этого повторил существующие стили (MarkdownEditor.css)

- Примеры отображения нового редактора:
<img src="https://github.com/user-attachments/assets/af1f3647-41d7-4782-9180-cb143efe1bf2" width="500" />
<img src="https://github.com/user-attachments/assets/d2f24cc0-9fa4-4e45-8609-8d93e0ea0c83" width="500" />
<img src="https://github.com/user-attachments/assets/72b78698-60bc-4ac0-a99b-ab633c5618a8" width="500" />
<img src="https://github.com/user-attachments/assets/55b65913-5b9a-4543-9d11-e2bae04690c2" width="500" />

### И preview-компонента:
<img src="https://github.com/user-attachments/assets/8f06d864-9c91-42ab-b380-4788edc1c907" width="500" />
<img src="https://github.com/user-attachments/assets/fe96acd6-3945-4813-9d84-4c79291fd921" width="500" />
<img src="https://github.com/user-attachments/assets/3a0b4111-3ae9-473b-a9ee-0ca30bfee815" width="500" />