### PR TITLE
Добавить поддержку шаблонов курсов

### DIFF
--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -76,16 +76,7 @@ namespace HwProj.APIGateway.API.Controllers
         [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> CreateCourse(CreateCourseViewModel model)
         {
-            var result = await _coursesClient.CreateCourse(model, UserId);
-            return Ok(result);
-        }
-
-        [HttpPost("createBasedOn/{courseId}")]
-        [Authorize(Roles = Roles.LecturerRole)]
-        [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
-        public async Task<IActionResult> CreateCourseBasedOn(long courseId, CreateCourseViewModel model)
-        {
-            var result = await _coursesClient.CreateCourseBasedOn(courseId, model);
+            var result = await _coursesClient.CreateCourse(model);
             return result.Succeeded
                 ? Ok(result.Value) as IActionResult
                 : BadRequest(result.Errors);

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -77,7 +77,9 @@ namespace HwProj.APIGateway.API.Controllers
         public async Task<IActionResult> RecreateCourse(long courseId)
         {
             var result = await _coursesClient.RecreateCourse(courseId, UserId);
-            return Ok(result);
+            return result.Succeeded
+                ? Ok(result.Value) as IActionResult
+                : BadRequest(result.Errors);
         }
 
         [HttpPost("create")]

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -85,7 +85,7 @@ namespace HwProj.APIGateway.API.Controllers
         [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> CreateCourseBasedOn(long courseId, CreateCourseViewModel model)
         {
-            var result = await _coursesClient.CreateCourseBasedOn(courseId, model, UserId);
+            var result = await _coursesClient.CreateCourseBasedOn(courseId, model);
             return result.Succeeded
                 ? Ok(result.Value) as IActionResult
                 : BadRequest(result.Errors);

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -71,6 +71,15 @@ namespace HwProj.APIGateway.API.Controllers
             return Ok();
         }
 
+        [HttpPost("recreate/{courseId}")]
+        [Authorize(Roles = Roles.LecturerRole)]
+        [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> RecreateCourse(long courseId)
+        {
+            var result = await _coursesClient.RecreateCourse(courseId, UserId);
+            return Ok(result);
+        }
+
         [HttpPost("create")]
         [Authorize(Roles = Roles.LecturerRole)]
         [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]

--- a/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
+++ b/HwProj.APIGateway/HwProj.APIGateway.API/Controllers/CoursesController.cs
@@ -71,17 +71,6 @@ namespace HwProj.APIGateway.API.Controllers
             return Ok();
         }
 
-        [HttpPost("recreate/{courseId}")]
-        [Authorize(Roles = Roles.LecturerRole)]
-        [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
-        public async Task<IActionResult> RecreateCourse(long courseId)
-        {
-            var result = await _coursesClient.RecreateCourse(courseId, UserId);
-            return result.Succeeded
-                ? Ok(result.Value) as IActionResult
-                : BadRequest(result.Errors);
-        }
-
         [HttpPost("create")]
         [Authorize(Roles = Roles.LecturerRole)]
         [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
@@ -89,6 +78,17 @@ namespace HwProj.APIGateway.API.Controllers
         {
             var result = await _coursesClient.CreateCourse(model, UserId);
             return Ok(result);
+        }
+
+        [HttpPost("createBasedOn/{courseId}")]
+        [Authorize(Roles = Roles.LecturerRole)]
+        [ProducesResponseType(typeof(long), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> CreateCourseBasedOn(long courseId, CreateCourseViewModel model)
+        {
+            var result = await _coursesClient.CreateCourseBasedOn(courseId, model, UserId);
+            return result.Succeeded
+                ? Ok(result.Value) as IActionResult
+                : BadRequest(result.Errors);
         }
 
         [HttpPost("update/{courseId}")]

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/CourseViewModels.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/CourseViewModels.cs
@@ -15,6 +15,8 @@ namespace HwProj.Models.CoursesService.ViewModels
         public string GroupName { get; set; }
 
         [Required] public bool IsOpen { get; set; }
+
+        public long? BaseCourseId { get; set; }
     }
 
     public class UpdateCourseViewModel

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkTaskViewModels.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkTaskViewModels.cs
@@ -26,6 +26,8 @@ namespace HwProj.Models.CoursesService.ViewModels
 
         public DateTime? PublicationDate { get; set; }
 
+        public bool PublicationDateNotSet { get; set; }
+
         public long HomeworkId { get; set; }
 
         public bool IsGroupWork { get; set; }

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkTaskViewModels.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkTaskViewModels.cs
@@ -28,6 +28,8 @@ namespace HwProj.Models.CoursesService.ViewModels
 
         public bool PublicationDateNotSet { get; set; }
 
+        public bool DeadlineDateNotSet { get; set; }
+
         public long HomeworkId { get; set; }
 
         public bool IsGroupWork { get; set; }

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkViewModels.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkViewModels.cs
@@ -43,6 +43,8 @@ namespace HwProj.Models.CoursesService.ViewModels
 
         public DateTime PublicationDate { get; set; }
 
+        public bool PublicationDateNotSet { get; set; }
+
         public long CourseId { get; set; }
 
         public bool IsDeferred { get; set; }

--- a/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkViewModels.cs
+++ b/HwProj.Common/HwProj.Models/CoursesService/ViewModels/HomeworkViewModels.cs
@@ -45,6 +45,8 @@ namespace HwProj.Models.CoursesService.ViewModels
 
         public bool PublicationDateNotSet { get; set; }
 
+        public bool DeadlineDateNotSet { get; set; }
+
         public long CourseId { get; set; }
 
         public bool IsDeferred { get; set; }

--- a/HwProj.Common/HwProj.Repositories/CrudRepository.cs
+++ b/HwProj.Common/HwProj.Repositories/CrudRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Z.EntityFramework.Plus;
 
@@ -21,6 +22,18 @@ namespace HwProj.Repositories
             await Context.AddAsync(item).ConfigureAwait(false);
             await Context.SaveChangesAsync().ConfigureAwait(false);
             return item.Id;
+        }
+
+        public async Task<List<TKey>> AddRangeAsync(IEnumerable<TEntity> items)
+        {
+            var result = new List<TKey>();
+
+            foreach (var item in items)
+            {
+                result.Add(await AddAsync(item));
+            }
+
+            return result;
         }
 
         public async Task DeleteAsync(TKey id)

--- a/HwProj.Common/HwProj.Repositories/CrudRepository.cs
+++ b/HwProj.Common/HwProj.Repositories/CrudRepository.cs
@@ -26,14 +26,10 @@ namespace HwProj.Repositories
 
         public async Task<List<TKey>> AddRangeAsync(IEnumerable<TEntity> items)
         {
-            var result = new List<TKey>();
-
-            foreach (var item in items)
-            {
-                result.Add(await AddAsync(item));
-            }
-
-            return result;
+            items = items.ToList();
+            await Context.AddRangeAsync(items).ConfigureAwait(false);
+            await Context.SaveChangesAsync().ConfigureAwait(false);
+            return items.Select(item => item.Id).ToList();
         }
 
         public async Task DeleteAsync(TKey id)

--- a/HwProj.Common/HwProj.Repositories/CrudRepository.cs
+++ b/HwProj.Common/HwProj.Repositories/CrudRepository.cs
@@ -27,8 +27,8 @@ namespace HwProj.Repositories
         public async Task<List<TKey>> AddRangeAsync(IEnumerable<TEntity> items)
         {
             items = items.ToList();
-            await Context.AddRangeAsync(items).ConfigureAwait(false);
-            await Context.SaveChangesAsync().ConfigureAwait(false);
+            await Context.AddRangeAsync(items);
+            await Context.SaveChangesAsync();
             return items.Select(item => item.Id).ToList();
         }
 

--- a/HwProj.Common/HwProj.Repositories/ICrudRepository.cs
+++ b/HwProj.Common/HwProj.Repositories/ICrudRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace HwProj.Repositories
 {
@@ -9,6 +10,7 @@ namespace HwProj.Repositories
         where TKey : IEquatable<TKey>
     {
         Task<TKey> AddAsync(TEntity item);
+        Task<List<TKey>> AddRangeAsync(IEnumerable<TEntity> items);
         Task DeleteAsync(TKey id);
         Task UpdateAsync(TKey id, Expression<Func<TEntity, TEntity>> updateFactory);
     }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -106,6 +106,18 @@ namespace HwProj.CoursesService.API.Controllers
             return Ok(id);
         }
 
+        [HttpPost("recreate/{courseId}")]
+        [ServiceFilter(typeof(CourseMentorOnlyAttribute))]
+        public async Task<IActionResult> RecreateCourse(long courseId, [FromQuery] string mentorId)
+        {
+            var course = await _coursesService.GetAsync(courseId);
+            if (course == null) return NotFound();
+
+            var courseTemplate = course.ToCourseTemplate();
+
+            return await AddCourseFromTemplate(courseTemplate, mentorId);
+        }
+
         [HttpDelete("{courseId}")]
         [ServiceFilter(typeof(CourseMentorOnlyAttribute))]
         public async Task<IActionResult> DeleteCourse(long courseId)
@@ -248,17 +260,6 @@ namespace HwProj.CoursesService.API.Controllers
             result = result.Concat(defaultTags).Distinct().ToArray();
 
             return Ok(result);
-        }
-
-        [HttpPost("recreate/{courseId}")]
-        public async Task<IActionResult> RecreateCourse(long courseId, [FromQuery] string mentorId)
-        {
-            var course = await _coursesService.GetAsync(courseId, mentorId);
-            if (course == null) return NotFound();
-
-            var courseTemplate = course.ToCourseTemplate();
-
-            return await AddCourseFromTemplate(courseTemplate, mentorId);
         }
 
         private async Task<IActionResult> AddCourseFromTemplate(CourseTemplate courseTemplate, string mentorId)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -264,13 +264,13 @@ namespace HwProj.CoursesService.API.Controllers
 
         private async Task<IActionResult> AddCourseFromTemplate(CourseTemplate courseTemplate, string mentorId)
         {
-            var currentDate = DateTime.UtcNow;
+            var publicationDate = DateTime.UtcNow + TimeSpan.FromDays(365);
 
             var courseId = await _coursesService.AddAsync(courseTemplate.ToCourse(), mentorId);
             foreach (var homeworkTemplate in courseTemplate.Homeworks)
             {
                 var homework = homeworkTemplate.ToHomework();
-                homework.PublicationDate = currentDate;
+                homework.PublicationDate = publicationDate;
 
                 var homeworkId = await _homeworksService.AddHomeworkAsync(courseId, homework);
                 foreach (var taskTemplate in homeworkTemplate.Tasks)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -94,19 +94,17 @@ namespace HwProj.CoursesService.API.Controllers
         public async Task<IActionResult> AddCourse([FromBody] CreateCourseViewModel courseViewModel)
         {
             var mentorId = Request.GetUserIdFromHeader();
-            var courseTemplate = courseViewModel.ToCourseTemplate();
+            CourseDTO? baseCourse = null;
 
             if (courseViewModel.BaseCourseId != null)
             {
-                var baseCourse = await _coursesService.GetAsync((long)courseViewModel.BaseCourseId);
+                baseCourse = await _coursesService.GetAsync((long)courseViewModel.BaseCourseId);
                 if (baseCourse == null) return NotFound();
 
                 if (!baseCourse.MentorIds.Contains(mentorId)) return Forbid();
-
-                courseTemplate.Homeworks = baseCourse.Homeworks.Select(h => h.ToHomeworkTemplate()).ToList();
             }
 
-            var courseId = await _coursesService.AddFromTemplateAsync(courseTemplate, mentorId);
+            var courseId = await _coursesService.AddAsync(courseViewModel, baseCourse, mentorId);
             return Ok(courseId);
         }
 

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -264,10 +264,15 @@ namespace HwProj.CoursesService.API.Controllers
 
         private async Task<IActionResult> AddCourseFromTemplate(CourseTemplate courseTemplate, string mentorId)
         {
+            var currentDate = DateTime.UtcNow;
+
             var courseId = await _coursesService.AddAsync(courseTemplate.ToCourse(), mentorId);
             foreach (var homeworkTemplate in courseTemplate.Homeworks)
             {
-                var homeworkId = await _homeworksService.AddHomeworkAsync(courseId, homeworkTemplate.ToHomework());
+                var homework = homeworkTemplate.ToHomework();
+                homework.PublicationDate = currentDate;
+
+                var homeworkId = await _homeworksService.AddHomeworkAsync(courseId, homework);
                 foreach (var taskTemplate in homeworkTemplate.Tasks)
                 {
                     await _tasksService.AddTaskAsync(homeworkId, taskTemplate.ToHomeworkTask());

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -100,14 +100,16 @@ namespace HwProj.CoursesService.API.Controllers
             return Ok(id);
         }
 
-        [HttpPost("recreate/{courseId}")]
+        [HttpPost("createBasedOn/{courseId}")]
         [ServiceFilter(typeof(CourseMentorOnlyAttribute))]
-        public async Task<IActionResult> RecreateCourse(long courseId, [FromQuery] string mentorId)
+        public async Task<IActionResult> AddCourseBasedOn(long courseId,
+            [FromBody] CreateCourseViewModel courseViewModel,
+            [FromQuery] string mentorId)
         {
-            var course = await _coursesService.GetAsync(courseId);
-            if (course == null) return NotFound();
+            var baseCourse = await _coursesService.GetAsync(courseId);
+            if (baseCourse == null) return NotFound();
 
-            var courseTemplate = course.ToCourseTemplate();
+            var courseTemplate = courseViewModel.ToCourseTemplate(baseCourse);
             courseId = await _coursesService.AddFromTemplateAsync(courseTemplate, mentorId);
 
             return Ok(courseId);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -10,7 +10,6 @@ using HwProj.Utils.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;
 using System.Net;
-using HwProj.AuthService.Client;
 using HwProj.CoursesService.API.Repositories;
 using HwProj.Models.AuthService.DTO;
 using HwProj.Models.CoursesService.DTO;

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using AutoMapper;
 using HwProj.CoursesService.API.Filters;
 using HwProj.CoursesService.API.Models;
 using HwProj.CoursesService.API.Services;
@@ -27,16 +26,13 @@ namespace HwProj.CoursesService.API.Controllers
         private readonly ICoursesService _coursesService;
         private readonly ICourseFilterService _courseFilterService;
         private readonly IHomeworksRepository _homeworksRepository;
-        private readonly IMapper _mapper;
 
         public CoursesController(ICoursesService coursesService,
             IHomeworksRepository homeworksRepository,
-            IMapper mapper,
             ICourseFilterService courseFilterService)
         {
             _coursesService = coursesService;
             _homeworksRepository = homeworksRepository;
-            _mapper = mapper;
             _courseFilterService = courseFilterService;
         }
 
@@ -98,7 +94,7 @@ namespace HwProj.CoursesService.API.Controllers
 
             if (courseViewModel.BaseCourseId != null)
             {
-                baseCourse = await _coursesService.GetAsync((long)courseViewModel.BaseCourseId);
+                baseCourse = await _coursesService.GetForEditingAsync((long)courseViewModel.BaseCourseId);
                 if (baseCourse == null) return NotFound();
 
                 if (!baseCourse.MentorIds.Contains(mentorId)) return Forbid();

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Controllers/CoursesController.cs
@@ -102,12 +102,12 @@ namespace HwProj.CoursesService.API.Controllers
         [HttpPost("createBasedOn/{courseId}")]
         [ServiceFilter(typeof(CourseMentorOnlyAttribute))]
         public async Task<IActionResult> AddCourseBasedOn(long courseId,
-            [FromBody] CreateCourseViewModel courseViewModel,
-            [FromQuery] string mentorId)
+            [FromBody] CreateCourseViewModel courseViewModel)
         {
             var baseCourse = await _coursesService.GetAsync(courseId);
             if (baseCourse == null) return NotFound();
 
+            var mentorId = Request.GetUserIdFromHeader();
             var courseTemplate = courseViewModel.ToCourseTemplate(baseCourse);
             courseId = await _coursesService.AddFromTemplateAsync(courseTemplate, mentorId);
 

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -113,14 +113,12 @@ namespace HwProj.CoursesService.API.Domains
                 Tags = createHomeworkViewModel.Tags.Join(";"),
             };
 
-        public static CourseTemplate ToCourseTemplate(
-            this CreateCourseViewModel createCourseViewModel, CourseDTO baseCourse)
+        public static CourseTemplate ToCourseTemplate(this CreateCourseViewModel createCourseViewModel)
             => new CourseTemplate()
             {
                 Name = createCourseViewModel.Name,
                 GroupName = createCourseViewModel.GroupName,
                 IsOpen = createCourseViewModel.IsOpen,
-                Homeworks = baseCourse.Homeworks.Select(h => h.ToHomeworkTemplate()).ToList(),
             };
 
         public static CourseTemplate ToCourseTemplate(this CourseDTO course)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -172,6 +172,7 @@ namespace HwProj.CoursesService.API.Domains
                 Tags = homeworkTemplate.Tags,
                 CourseId = courseId,
                 PublicationDate = publicationDate,
+                DeadlineDate = homeworkTemplate.HasDeadline ? publicationDate : (DateTime?)null
             };
 
         public static HomeworkTask ToHomeworkTask(

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -9,6 +9,8 @@ namespace HwProj.CoursesService.API.Domains
 {
     public static class MappingExtensions
     {
+        private static readonly DateTime DateToOverride = DateTime.MaxValue;
+
         public static HomeworkViewModel ToHomeworkViewModel(this Homework homework)
         {
             var tags = homework.Tags?.Split(';') ?? Array.Empty<string>();
@@ -21,7 +23,8 @@ namespace HwProj.CoursesService.API.Domains
                 DeadlineDate = homework.DeadlineDate,
                 IsDeadlineStrict = homework.IsDeadlineStrict,
                 PublicationDate = homework.PublicationDate,
-                PublicationDateNotSet = homework.PublicationDate == DateTime.MaxValue,
+                PublicationDateNotSet = homework.PublicationDate == DateToOverride,
+                DeadlineDateNotSet = homework.DeadlineDate == null || homework.DeadlineDate == DateToOverride,
                 CourseId = homework.CourseId,
                 IsGroupWork = tags.Contains(HomeworkTags.GroupWork),
                 IsDeferred = DateTime.UtcNow < homework.PublicationDate,
@@ -44,7 +47,8 @@ namespace HwProj.CoursesService.API.Domains
                 DeadlineDate = task.DeadlineDate,
                 IsDeadlineStrict = task.IsDeadlineStrict,
                 PublicationDate = task.PublicationDate,
-                PublicationDateNotSet = task.PublicationDate == DateTime.MaxValue,
+                PublicationDateNotSet = task.PublicationDate == null || task.PublicationDate == DateToOverride,
+                DeadlineDateNotSet = task.DeadlineDate == null || task.DeadlineDate == DateToOverride,
                 IsDeferred = DateTime.UtcNow < evaluatedPublicationDate,
                 IsGroupWork = tags.Contains(HomeworkTags.GroupWork),
                 HomeworkId = task.HomeworkId,
@@ -151,6 +155,8 @@ namespace HwProj.CoursesService.API.Domains
                 MaxRating = task.MaxRating,
                 HasDeadline = task.HasDeadline,
                 IsDeadlineStrict = task.IsDeadlineStrict,
+                HasSpecialPublicationDate = task.PublicationDate != null,
+                HasSpecialDeadlineDate = task.DeadlineDate != null,
             };
 
         public static Course ToCourse(this CourseTemplate courseTemplate)
@@ -170,7 +176,7 @@ namespace HwProj.CoursesService.API.Domains
                 IsDeadlineStrict = homeworkTemplate.IsDeadlineStrict,
                 Tags = homeworkTemplate.Tags,
                 CourseId = courseId,
-                PublicationDate = DateTime.MaxValue,
+                PublicationDate = DateToOverride,
             };
 
         public static HomeworkTask ToHomeworkTask(this HomeworkTaskTemplate taskTemplate, long homeworkId)
@@ -182,6 +188,8 @@ namespace HwProj.CoursesService.API.Domains
                 HasDeadline = taskTemplate.HasDeadline,
                 IsDeadlineStrict = taskTemplate.IsDeadlineStrict,
                 HomeworkId = homeworkId,
+                PublicationDate = taskTemplate.HasSpecialPublicationDate ? DateToOverride : (DateTime?)null,
+                DeadlineDate = taskTemplate.HasSpecialDeadlineDate ? DateToOverride : (DateTime?)null,
             };
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -113,6 +113,16 @@ namespace HwProj.CoursesService.API.Domains
                 Tags = createHomeworkViewModel.Tags.Join(";"),
             };
 
+        public static CourseTemplate ToCourseTemplate(
+            this CreateCourseViewModel createCourseViewModel, CourseDTO baseCourse)
+            => new CourseTemplate()
+            {
+                Name = createCourseViewModel.Name,
+                GroupName = createCourseViewModel.GroupName,
+                IsOpen = createCourseViewModel.IsOpen,
+                Homeworks = baseCourse.Homeworks.Select(h => h.ToHomeworkTemplate()).ToList(),
+            };
+
         public static CourseTemplate ToCourseTemplate(this CourseDTO course)
             => new CourseTemplate()
             {
@@ -152,7 +162,7 @@ namespace HwProj.CoursesService.API.Domains
             };
 
         public static Homework ToHomework(
-            this HomeworkTemplate homeworkTemplate, long? courseId, DateTime? publicationDate)
+            this HomeworkTemplate homeworkTemplate, long courseId, DateTime publicationDate)
             => new Homework()
             {
                 Title = homeworkTemplate.Title,
@@ -160,12 +170,12 @@ namespace HwProj.CoursesService.API.Domains
                 HasDeadline = homeworkTemplate.HasDeadline,
                 IsDeadlineStrict = homeworkTemplate.IsDeadlineStrict,
                 Tags = homeworkTemplate.Tags,
-                CourseId = courseId ?? default,
-                PublicationDate = publicationDate ?? default,
+                CourseId = courseId,
+                PublicationDate = publicationDate,
             };
 
         public static HomeworkTask ToHomeworkTask(
-            this HomeworkTaskTemplate taskTemplate, long? homeworkId)
+            this HomeworkTaskTemplate taskTemplate, long homeworkId)
             => new HomeworkTask()
             {
                 Title = taskTemplate.Title,
@@ -173,7 +183,7 @@ namespace HwProj.CoursesService.API.Domains
                 MaxRating = taskTemplate.MaxRating,
                 HasDeadline = taskTemplate.HasDeadline,
                 IsDeadlineStrict = taskTemplate.IsDeadlineStrict,
-                HomeworkId = homeworkId ?? default,
+                HomeworkId = homeworkId,
             };
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -112,5 +112,34 @@ namespace HwProj.CoursesService.API.Domains
                 Tasks = createHomeworkViewModel.Tasks.Select(t => t.ToHomeworkTask()).ToList(),
                 Tags = createHomeworkViewModel.Tags.Join(";"),
             };
+
+        public static CourseTemplate ToCourseTemplate(this Course course)
+            => new CourseTemplate()
+            {
+                Name = course.Name,
+                GroupName = course.GroupName,
+                Homeworks = course.Homeworks.Select(h => h.ToHomeworkTemplate()).ToList(),
+            };
+
+        public static HomeworkTemplate ToHomeworkTemplate(this Homework homework)
+            => new HomeworkTemplate()
+            {
+                Title = homework.Title,
+                Description = homework.Description,
+                HasDeadline = homework.HasDeadline,
+                IsDeadlineStrict = homework.IsDeadlineStrict,
+                Tags = homework.Tags,
+                Tasks = homework.Tasks.Select(t => t.ToHomeworkTaskTemplate()).ToList(),
+            };
+
+        public static HomeworkTaskTemplate ToHomeworkTaskTemplate(this HomeworkTask task)
+            => new HomeworkTaskTemplate()
+            {
+                Title = task.Title,
+                Description = task.Description,
+                MaxRating = task.MaxRating,
+                HasDeadline = task.HasDeadline,
+                IsDeadlineStrict = task.IsDeadlineStrict,
+            };
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -113,26 +113,27 @@ namespace HwProj.CoursesService.API.Domains
                 Tags = createHomeworkViewModel.Tags.Join(";"),
             };
 
-        public static CourseTemplate ToCourseTemplate(this Course course)
+        public static CourseTemplate ToCourseTemplate(this CourseDTO course)
             => new CourseTemplate()
             {
                 Name = course.Name,
                 GroupName = course.GroupName,
+                IsOpen = course.IsOpen,
                 Homeworks = course.Homeworks.Select(h => h.ToHomeworkTemplate()).ToList(),
             };
 
-        public static HomeworkTemplate ToHomeworkTemplate(this Homework homework)
+        public static HomeworkTemplate ToHomeworkTemplate(this HomeworkViewModel homework)
             => new HomeworkTemplate()
             {
                 Title = homework.Title,
                 Description = homework.Description,
                 HasDeadline = homework.HasDeadline,
                 IsDeadlineStrict = homework.IsDeadlineStrict,
-                Tags = homework.Tags,
+                Tags = homework.Tags.Join(";"),
                 Tasks = homework.Tasks.Select(t => t.ToHomeworkTaskTemplate()).ToList(),
             };
 
-        public static HomeworkTaskTemplate ToHomeworkTaskTemplate(this HomeworkTask task)
+        public static HomeworkTaskTemplate ToHomeworkTaskTemplate(this HomeworkTaskViewModel task)
             => new HomeworkTaskTemplate()
             {
                 Title = task.Title,
@@ -140,6 +141,34 @@ namespace HwProj.CoursesService.API.Domains
                 MaxRating = task.MaxRating,
                 HasDeadline = task.HasDeadline,
                 IsDeadlineStrict = task.IsDeadlineStrict,
+            };
+
+        public static Course ToCourse(this CourseTemplate courseTemplate)
+            => new Course()
+            {
+                Name = courseTemplate.Name,
+                GroupName = courseTemplate.GroupName,
+                IsOpen = courseTemplate.IsOpen,
+            };
+
+        public static Homework ToHomework(this HomeworkTemplate homeworkTemplate)
+            => new Homework()
+            {
+                Title = homeworkTemplate.Title,
+                Description = homeworkTemplate.Description,
+                HasDeadline = homeworkTemplate.HasDeadline,
+                IsDeadlineStrict = homeworkTemplate.IsDeadlineStrict,
+                Tags = homeworkTemplate.Tags,
+            };
+
+        public static HomeworkTask ToHomeworkTask(this HomeworkTaskTemplate taskTemplate)
+            => new HomeworkTask()
+            {
+                Title = taskTemplate.Title,
+                Description = taskTemplate.Description,
+                MaxRating = taskTemplate.MaxRating,
+                HasDeadline = taskTemplate.HasDeadline,
+                IsDeadlineStrict = taskTemplate.IsDeadlineStrict,
             };
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -151,7 +151,8 @@ namespace HwProj.CoursesService.API.Domains
                 IsOpen = courseTemplate.IsOpen,
             };
 
-        public static Homework ToHomework(this HomeworkTemplate homeworkTemplate)
+        public static Homework ToHomework(
+            this HomeworkTemplate homeworkTemplate, long? courseId, DateTime? publicationDate)
             => new Homework()
             {
                 Title = homeworkTemplate.Title,
@@ -159,9 +160,12 @@ namespace HwProj.CoursesService.API.Domains
                 HasDeadline = homeworkTemplate.HasDeadline,
                 IsDeadlineStrict = homeworkTemplate.IsDeadlineStrict,
                 Tags = homeworkTemplate.Tags,
+                CourseId = courseId ?? default,
+                PublicationDate = publicationDate ?? default,
             };
 
-        public static HomeworkTask ToHomeworkTask(this HomeworkTaskTemplate taskTemplate)
+        public static HomeworkTask ToHomeworkTask(
+            this HomeworkTaskTemplate taskTemplate, long? homeworkId)
             => new HomeworkTask()
             {
                 Title = taskTemplate.Title,
@@ -169,6 +173,7 @@ namespace HwProj.CoursesService.API.Domains
                 MaxRating = taskTemplate.MaxRating,
                 HasDeadline = taskTemplate.HasDeadline,
                 IsDeadlineStrict = taskTemplate.IsDeadlineStrict,
+                HomeworkId = homeworkId ?? default,
             };
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -170,7 +170,6 @@ namespace HwProj.CoursesService.API.Domains
                 Tags = homeworkTemplate.Tags,
                 CourseId = courseId,
                 PublicationDate = publicationDate,
-                DeadlineDate = homeworkTemplate.HasDeadline ? publicationDate : (DateTime?)null
             };
 
         public static HomeworkTask ToHomeworkTask(

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Domains/MappingExtensions.cs
@@ -21,6 +21,7 @@ namespace HwProj.CoursesService.API.Domains
                 DeadlineDate = homework.DeadlineDate,
                 IsDeadlineStrict = homework.IsDeadlineStrict,
                 PublicationDate = homework.PublicationDate,
+                PublicationDateNotSet = homework.PublicationDate == DateTime.MaxValue,
                 CourseId = homework.CourseId,
                 IsGroupWork = tags.Contains(HomeworkTags.GroupWork),
                 IsDeferred = DateTime.UtcNow < homework.PublicationDate,
@@ -43,6 +44,7 @@ namespace HwProj.CoursesService.API.Domains
                 DeadlineDate = task.DeadlineDate,
                 IsDeadlineStrict = task.IsDeadlineStrict,
                 PublicationDate = task.PublicationDate,
+                PublicationDateNotSet = task.PublicationDate == DateTime.MaxValue,
                 IsDeferred = DateTime.UtcNow < evaluatedPublicationDate,
                 IsGroupWork = tags.Contains(HomeworkTags.GroupWork),
                 HomeworkId = task.HomeworkId,
@@ -159,8 +161,7 @@ namespace HwProj.CoursesService.API.Domains
                 IsOpen = courseTemplate.IsOpen,
             };
 
-        public static Homework ToHomework(
-            this HomeworkTemplate homeworkTemplate, long courseId, DateTime publicationDate)
+        public static Homework ToHomework(this HomeworkTemplate homeworkTemplate, long courseId)
             => new Homework()
             {
                 Title = homeworkTemplate.Title,
@@ -169,11 +170,10 @@ namespace HwProj.CoursesService.API.Domains
                 IsDeadlineStrict = homeworkTemplate.IsDeadlineStrict,
                 Tags = homeworkTemplate.Tags,
                 CourseId = courseId,
-                PublicationDate = publicationDate,
+                PublicationDate = DateTime.MaxValue,
             };
 
-        public static HomeworkTask ToHomeworkTask(
-            this HomeworkTaskTemplate taskTemplate, long homeworkId)
+        public static HomeworkTask ToHomeworkTask(this HomeworkTaskTemplate taskTemplate, long homeworkId)
             => new HomeworkTask()
             {
                 Title = taskTemplate.Title,

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/CourseTemplate.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/CourseTemplate.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace HwProj.CoursesService.API.Models
+{
+    public class CourseTemplate
+    {
+        public string Name { get; set; }
+
+        public string GroupName { get; set; }
+
+        public List<HomeworkTemplate> Homeworks { get; set; } = new List<HomeworkTemplate>();
+    }
+}

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/CourseTemplate.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/CourseTemplate.cs
@@ -8,6 +8,8 @@ namespace HwProj.CoursesService.API.Models
 
         public string GroupName { get; set; }
 
+        public bool IsOpen { get; set; }
+
         public List<HomeworkTemplate> Homeworks { get; set; } = new List<HomeworkTemplate>();
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTaskTemplate.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTaskTemplate.cs
@@ -11,5 +11,9 @@ namespace HwProj.CoursesService.API.Models
         public bool? HasDeadline { get; set; }
 
         public bool? IsDeadlineStrict { get; set; }
+
+        public bool HasSpecialPublicationDate { get; set; }
+
+        public bool HasSpecialDeadlineDate { get; set; }
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTaskTemplate.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTaskTemplate.cs
@@ -1,0 +1,15 @@
+namespace HwProj.CoursesService.API.Models
+{
+    public class HomeworkTaskTemplate
+    {
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+
+        public int MaxRating { get; set; }
+
+        public bool? HasDeadline { get; set; }
+
+        public bool? IsDeadlineStrict { get; set; }
+    }
+}

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTemplate.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTemplate.cs
@@ -14,6 +14,6 @@ namespace HwProj.CoursesService.API.Models
 
         public string? Tags { get; set; }
 
-        public List<HomeworkTaskTemplate> Tasks { get; set; }
+        public List<HomeworkTaskTemplate> Tasks { get; set; } = new List<HomeworkTaskTemplate>();
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTemplate.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Models/HomeworkTemplate.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace HwProj.CoursesService.API.Models
+{
+    public class HomeworkTemplate
+    {
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+
+        public bool HasDeadline { get; set; }
+
+        public bool IsDeadlineStrict { get; set; }
+
+        public string? Tags { get; set; }
+
+        public List<HomeworkTaskTemplate> Tasks { get; set; }
+    }
+}

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Repositories/CoursesRepository.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Repositories/CoursesRepository.cs
@@ -19,6 +19,13 @@ namespace HwProj.CoursesService.API.Repositories
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.Id == id);
 
+        public async Task<Course?> GetWithHomeworksAsync(long id)
+            => await Context.Set<Course>()
+                .Include(c => c.Homeworks)
+                .ThenInclude(h => h.Tasks)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == id);
+
         public async Task<Course?> GetWithCourseMatesAndHomeworksAsync(long id)
         {
             var course = await Context.Set<Course>()

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Repositories/ICoursesRepository.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Repositories/ICoursesRepository.cs
@@ -8,6 +8,7 @@ namespace HwProj.CoursesService.API.Repositories
     public interface ICoursesRepository : ICrudRepository<Course, long>
     {
         Task<Course?> GetWithCourseMates(long id);
+        Task<Course?> GetWithHomeworksAsync(long id);
         Task<Course?> GetWithCourseMatesAndHomeworksAsync(long id);
         IQueryable<Course> GetAllWithCourseMatesAndHomeworks();
     }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -82,7 +82,7 @@ namespace HwProj.CoursesService.API.Services
 
         public async Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId)
         {
-            var publicationDate = DateTime.UtcNow + TimeSpan.FromDays(365);
+            var publicationDate = DateTime.MaxValue;
 
             using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -20,27 +20,29 @@ namespace HwProj.CoursesService.API.Services
     public class CoursesService : ICoursesService
     {
         private readonly ICoursesRepository _coursesRepository;
+        private readonly IHomeworksRepository _homeworksRepository;
+        private readonly ITasksRepository _tasksRepository;
         private readonly ICourseMatesRepository _courseMatesRepository;
         private readonly IEventBus _eventBus;
         private readonly IAuthServiceClient _authServiceClient;
-        private readonly ITasksRepository _tasksRepository;
         private readonly IGroupsRepository _groupsRepository;
         private readonly ICourseFilterService _courseFilterService;
 
         public CoursesService(ICoursesRepository coursesRepository,
+            IHomeworksRepository homeworksRepository,
+            ITasksRepository tasksRepository,
             ICourseMatesRepository courseMatesRepository,
             IEventBus eventBus,
             IAuthServiceClient authServiceClient,
-            ITasksRepository tasksRepository,
-            IHomeworksRepository homeworksRepository,
             IGroupsRepository groupsRepository,
             ICourseFilterService courseFilterService)
         {
             _coursesRepository = coursesRepository;
+            _homeworksRepository = homeworksRepository;
+            _tasksRepository = tasksRepository;
             _courseMatesRepository = courseMatesRepository;
             _eventBus = eventBus;
             _authServiceClient = authServiceClient;
-            _tasksRepository = tasksRepository;
             _groupsRepository = groupsRepository;
             _courseFilterService = courseFilterService;
         }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -98,8 +98,6 @@ namespace HwProj.CoursesService.API.Services
 
         public async Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId)
         {
-            var publicationDate = DateTime.MaxValue;
-
             using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
             var course = courseTemplate.ToCourse();
@@ -108,7 +106,7 @@ namespace HwProj.CoursesService.API.Services
             var courseId = await _coursesRepository.AddAsync(course);
 
             var homeworks = courseTemplate.Homeworks.Select(
-                hwTemplate => hwTemplate.ToHomework(courseId, publicationDate));
+                hwTemplate => hwTemplate.ToHomework(courseId));
             var homeworkIds = await _homeworksRepository.AddRangeAsync(homeworks);
 
             var tasks = courseTemplate.Homeworks.SelectMany((hwTemplate, i) =>

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -82,6 +82,12 @@ namespace HwProj.CoursesService.API.Services
             return result;
         }
 
+        public async Task<CourseDTO?> GetForEditingAsync(long id)
+        {
+            var course = await _coursesRepository.GetWithHomeworksAsync(id);
+            return course?.ToCourseDto();
+        }
+
         public async Task<long> AddAsync(CreateCourseViewModel courseViewModel,
             CourseDTO? baseCourse,
             string mentorId)

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -82,6 +82,20 @@ namespace HwProj.CoursesService.API.Services
             return result;
         }
 
+        public async Task<long> AddAsync(CreateCourseViewModel courseViewModel,
+            CourseDTO? baseCourse,
+            string mentorId)
+        {
+            var courseTemplate = courseViewModel.ToCourseTemplate();
+
+            if (baseCourse != null)
+            {
+                courseTemplate.Homeworks = baseCourse.Homeworks.Select(h => h.ToHomeworkTemplate()).ToList();
+            }
+
+            return await AddFromTemplateAsync(courseTemplate, mentorId);
+        }
+
         public async Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId)
         {
             var publicationDate = DateTime.MaxValue;

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
@@ -11,7 +11,7 @@ namespace HwProj.CoursesService.API.Services
         Task<Course[]> GetAllAsync();
         Task<CourseDTO?> GetAsync(long id, string userId = "");
         Task<CourseDTO?> GetByTaskAsync(long taskId, string userId);
-        Task<long> AddAsync(Course course, string mentorId);
+        Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId);
         Task DeleteAsync(long id);
         Task UpdateAsync(long courseId, Course updated);
         Task<bool> AddStudentAsync(long courseId, string studentId);
@@ -22,6 +22,5 @@ namespace HwProj.CoursesService.API.Services
         Task<AccountDataDto[]> GetLecturersAvailableForCourse(long courseId, string mentorId);
         Task<string[]> GetCourseLecturers(long courseId);
         Task<bool> HasStudent(long courseId, string studentId);
-        Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId);
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
@@ -11,6 +11,7 @@ namespace HwProj.CoursesService.API.Services
         Task<Course[]> GetAllAsync();
         Task<CourseDTO?> GetAsync(long id, string userId = "");
         Task<CourseDTO?> GetByTaskAsync(long taskId, string userId);
+        Task<long> AddAsync(CreateCourseViewModel courseViewModel, CourseDTO? baseCourse, string mentorId);
         Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId);
         Task DeleteAsync(long id);
         Task UpdateAsync(long courseId, Course updated);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
@@ -10,6 +10,7 @@ namespace HwProj.CoursesService.API.Services
     {
         Task<Course[]> GetAllAsync();
         Task<CourseDTO?> GetAsync(long id, string userId = "");
+        Task<CourseDTO?> GetForEditingAsync(long id);
         Task<CourseDTO?> GetByTaskAsync(long taskId, string userId);
         Task<long> AddAsync(CreateCourseViewModel courseViewModel, CourseDTO? baseCourse, string mentorId);
         Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId);

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/ICoursesService.cs
@@ -22,5 +22,6 @@ namespace HwProj.CoursesService.API.Services
         Task<AccountDataDto[]> GetLecturersAvailableForCourse(long courseId, string mentorId);
         Task<string[]> GetCourseLecturers(long courseId);
         Task<bool> HasStudent(long courseId, string studentId);
+        Task<long> AddFromTemplateAsync(CourseTemplate courseTemplate, string mentorId);
     }
 }

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -108,7 +108,7 @@ namespace HwProj.CoursesService.Client
             return response.IsSuccessStatusCode ? Result.Success() : Result.Failed(response.ReasonPhrase);
         }
 
-        public async Task<long> RecreateCourse(long courseId, string mentorId)
+        public async Task<Result<long>> RecreateCourse(long courseId, string mentorId)
         {
             using var httpRequest = new HttpRequestMessage(
                 HttpMethod.Post,
@@ -116,7 +116,11 @@ namespace HwProj.CoursesService.Client
 
             httpRequest.TryAddUserId(_httpContextAccessor);
             var response = await _httpClient.SendAsync(httpRequest);
-            return await response.DeserializeAsync<long>();
+            return response.StatusCode switch
+            {
+                HttpStatusCode.OK => Result<long>.Success(await response.DeserializeAsync<long>()),
+                _ => Result<long>.Failed(response.ReasonPhrase),
+            };
         }
 
         public async Task<long> CreateCourse(CreateCourseViewModel model, string mentorId)

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -124,13 +124,11 @@ namespace HwProj.CoursesService.Client
             return await response.DeserializeAsync<long>();
         }
 
-        public async Task<Result<long>> CreateCourseBasedOn(long courseId,
-            CreateCourseViewModel model,
-            string mentorId)
+        public async Task<Result<long>> CreateCourseBasedOn(long courseId, CreateCourseViewModel model)
         {
             using var httpRequest = new HttpRequestMessage(
                 HttpMethod.Post,
-                _coursesServiceUri + $"api/Courses/createBasedOn/{courseId}?mentorId={mentorId}")
+                _coursesServiceUri + $"api/Courses/createBasedOn/{courseId}")
             {
                 Content = new StringContent(
                     JsonConvert.SerializeObject(model),

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -108,6 +108,17 @@ namespace HwProj.CoursesService.Client
             return response.IsSuccessStatusCode ? Result.Success() : Result.Failed(response.ReasonPhrase);
         }
 
+        public async Task<long> RecreateCourse(long courseId, string mentorId)
+        {
+            using var httpRequest = new HttpRequestMessage(
+                HttpMethod.Post,
+                _coursesServiceUri + $"api/Courses/recreate/{courseId}?mentorId={mentorId}");
+
+            httpRequest.TryAddUserId(_httpContextAccessor);
+            var response = await _httpClient.SendAsync(httpRequest);
+            return await response.DeserializeAsync<long>();
+        }
+
         public async Task<long> CreateCourse(CreateCourseViewModel model, string mentorId)
         {
             using var httpRequest = new HttpRequestMessage(

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -108,21 +108,6 @@ namespace HwProj.CoursesService.Client
             return response.IsSuccessStatusCode ? Result.Success() : Result.Failed(response.ReasonPhrase);
         }
 
-        public async Task<Result<long>> RecreateCourse(long courseId, string mentorId)
-        {
-            using var httpRequest = new HttpRequestMessage(
-                HttpMethod.Post,
-                _coursesServiceUri + $"api/Courses/recreate/{courseId}?mentorId={mentorId}");
-
-            httpRequest.TryAddUserId(_httpContextAccessor);
-            var response = await _httpClient.SendAsync(httpRequest);
-            return response.StatusCode switch
-            {
-                HttpStatusCode.OK => Result<long>.Success(await response.DeserializeAsync<long>()),
-                _ => Result<long>.Failed(response.ReasonPhrase),
-            };
-        }
-
         public async Task<long> CreateCourse(CreateCourseViewModel model, string mentorId)
         {
             using var httpRequest = new HttpRequestMessage(
@@ -137,6 +122,29 @@ namespace HwProj.CoursesService.Client
 
             var response = await _httpClient.SendAsync(httpRequest);
             return await response.DeserializeAsync<long>();
+        }
+
+        public async Task<Result<long>> CreateCourseBasedOn(long courseId,
+            CreateCourseViewModel model,
+            string mentorId)
+        {
+            using var httpRequest = new HttpRequestMessage(
+                HttpMethod.Post,
+                _coursesServiceUri + $"api/Courses/createBasedOn/{courseId}?mentorId={mentorId}")
+            {
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(model),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+
+            httpRequest.TryAddUserId(_httpContextAccessor);
+            var response = await _httpClient.SendAsync(httpRequest);
+            return response.StatusCode switch
+            {
+                HttpStatusCode.OK => Result<long>.Success(await response.DeserializeAsync<long>()),
+                _ => Result<long>.Failed(response.ReasonPhrase),
+            };
         }
 
         public async Task<Result> UpdateCourse(UpdateCourseViewModel model, long courseId)

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -143,6 +143,7 @@ namespace HwProj.CoursesService.Client
             return response.StatusCode switch
             {
                 HttpStatusCode.OK => Result<long>.Success(await response.DeserializeAsync<long>()),
+                HttpStatusCode.NotFound => Result<long>.Failed("Базовый курс не найден"),
                 _ => Result<long>.Failed(response.ReasonPhrase),
             };
         }

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/CoursesServiceClient.cs
@@ -108,27 +108,11 @@ namespace HwProj.CoursesService.Client
             return response.IsSuccessStatusCode ? Result.Success() : Result.Failed(response.ReasonPhrase);
         }
 
-        public async Task<long> CreateCourse(CreateCourseViewModel model, string mentorId)
+        public async Task<Result<long>> CreateCourse(CreateCourseViewModel model)
         {
             using var httpRequest = new HttpRequestMessage(
                 HttpMethod.Post,
-                _coursesServiceUri + $"api/Courses/create?mentorId={mentorId}")
-            {
-                Content = new StringContent(
-                    JsonConvert.SerializeObject(model),
-                    Encoding.UTF8,
-                    "application/json")
-            };
-
-            var response = await _httpClient.SendAsync(httpRequest);
-            return await response.DeserializeAsync<long>();
-        }
-
-        public async Task<Result<long>> CreateCourseBasedOn(long courseId, CreateCourseViewModel model)
-        {
-            using var httpRequest = new HttpRequestMessage(
-                HttpMethod.Post,
-                _coursesServiceUri + $"api/Courses/createBasedOn/{courseId}")
+                _coursesServiceUri + $"api/Courses/create")
             {
                 Content = new StringContent(
                     JsonConvert.SerializeObject(model),
@@ -142,6 +126,7 @@ namespace HwProj.CoursesService.Client
             {
                 HttpStatusCode.OK => Result<long>.Success(await response.DeserializeAsync<long>()),
                 HttpStatusCode.NotFound => Result<long>.Failed("Базовый курс не найден"),
+                HttpStatusCode.Forbidden => Result<long>.Failed("Вы не являетесь ментором базового курса"),
                 _ => Result<long>.Failed(response.ReasonPhrase),
             };
         }

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -15,6 +15,7 @@ namespace HwProj.CoursesService.Client
         Task<Result<CourseDTO>> GetAllCourseData(long courseId);
         Task<CourseDTO?> GetCourseByTask(long taskId);
         Task<Result> DeleteCourse(long courseId);
+        Task<long> RecreateCourse(long courseId, string mentorId);
         Task<long> CreateCourse(CreateCourseViewModel model, string mentorId);
         Task<Result> UpdateCourse(UpdateCourseViewModel model, long courseId);
         Task SignInCourse(long courseId, string studentId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -15,8 +15,7 @@ namespace HwProj.CoursesService.Client
         Task<Result<CourseDTO>> GetAllCourseData(long courseId);
         Task<CourseDTO?> GetCourseByTask(long taskId);
         Task<Result> DeleteCourse(long courseId);
-        Task<long> CreateCourse(CreateCourseViewModel model, string mentorId);
-        Task<Result<long>> CreateCourseBasedOn(long courseId, CreateCourseViewModel model);
+        Task<Result<long>> CreateCourse(CreateCourseViewModel model);
         Task<Result> UpdateCourse(UpdateCourseViewModel model, long courseId);
         Task SignInCourse(long courseId, string studentId);
         Task<Result> AcceptStudent(long courseId, string studentId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -15,8 +15,8 @@ namespace HwProj.CoursesService.Client
         Task<Result<CourseDTO>> GetAllCourseData(long courseId);
         Task<CourseDTO?> GetCourseByTask(long taskId);
         Task<Result> DeleteCourse(long courseId);
-        Task<Result<long>> RecreateCourse(long courseId, string mentorId);
         Task<long> CreateCourse(CreateCourseViewModel model, string mentorId);
+        Task<Result<long>> CreateCourseBasedOn(long courseId, CreateCourseViewModel model, string mentorId);
         Task<Result> UpdateCourse(UpdateCourseViewModel model, long courseId);
         Task SignInCourse(long courseId, string studentId);
         Task<Result> AcceptStudent(long courseId, string studentId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -16,7 +16,7 @@ namespace HwProj.CoursesService.Client
         Task<CourseDTO?> GetCourseByTask(long taskId);
         Task<Result> DeleteCourse(long courseId);
         Task<long> CreateCourse(CreateCourseViewModel model, string mentorId);
-        Task<Result<long>> CreateCourseBasedOn(long courseId, CreateCourseViewModel model, string mentorId);
+        Task<Result<long>> CreateCourseBasedOn(long courseId, CreateCourseViewModel model);
         Task<Result> UpdateCourse(UpdateCourseViewModel model, long courseId);
         Task SignInCourse(long courseId, string studentId);
         Task<Result> AcceptStudent(long courseId, string studentId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Client/ICoursesServiceClient.cs
@@ -15,7 +15,7 @@ namespace HwProj.CoursesService.Client
         Task<Result<CourseDTO>> GetAllCourseData(long courseId);
         Task<CourseDTO?> GetCourseByTask(long taskId);
         Task<Result> DeleteCourse(long courseId);
-        Task<long> RecreateCourse(long courseId, string mentorId);
+        Task<Result<long>> RecreateCourse(long courseId, string mentorId);
         Task<long> CreateCourse(CreateCourseViewModel model, string mentorId);
         Task<Result> UpdateCourse(UpdateCourseViewModel model, long courseId);
         Task SignInCourse(long courseId, string studentId);

--- a/HwProj.CoursesService/HwProj.CoursesService.Tests/CoursesServiceTests.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Tests/CoursesServiceTests.cs
@@ -122,8 +122,8 @@ namespace HwProj.CoursesService.Tests
         private static async Task<long> CreateCourse(CoursesServiceClient courseClient, string userId)
         {
             var newCourseViewModel = GenerateCreateCourseViewModel();
-            var courseId = await courseClient.CreateCourse(newCourseViewModel, userId);
-            return courseId;
+            var courseId = await courseClient.CreateCourse(newCourseViewModel);
+            return courseId.Value;
         }
 
         private async Task<(long courseId, CoursesServiceClient client)> CreateClientAndCourse()

--- a/HwProj.CoursesService/HwProj.CoursesService.Tests/CoursesServiceTests.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.Tests/CoursesServiceTests.cs
@@ -144,8 +144,8 @@ namespace HwProj.CoursesService.Tests
             return (course.courseId, homework, homeworkResult, course.client);
         }
         
-        private async Task<(Result editResult, HomeworkTaskForEditingViewModel tasksFromDb)> AddTaskToHomeworkAndUpdate(
-            CreateTaskViewModel firstTaskState, CreateTaskViewModel secondTaskState)
+        private async Task<(Result<HomeworkTaskViewModel> editResult, HomeworkTaskForEditingViewModel tasksFromDb)>
+            AddTaskToHomeworkAndUpdate(CreateTaskViewModel firstTaskState, CreateTaskViewModel secondTaskState)
         {
             var homework = GenerateDefaultHomeworkViewModel();
             var homeworkResult = await client.AddHomeworkToCourse(homework, courseId);

--- a/HwProj.SolutionsService/HwProj.SolutionsService.IntegrationTests/SolutionsServiceTests.cs
+++ b/HwProj.SolutionsService/HwProj.SolutionsService.IntegrationTests/SolutionsServiceTests.cs
@@ -131,8 +131,8 @@ namespace HwProj.SolutionsService.IntegrationTests
         private async Task<long> CreateCourse(CoursesServiceClient courseClient, string userId)
         {
             var newCourseViewModel = GenerateCreateCourseViewModel();
-            var courseId = await courseClient.CreateCourse(newCourseViewModel, userId);
-            return courseId;
+            var courseId = await courseClient.CreateCourse(newCourseViewModel);
+            return courseId.Value;
         }
 
         private async Task SignStudentInCourse(

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -4223,6 +4223,47 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
         /**
          *
          * @param {number} courseId
+         * @param {CreateCourseViewModel} [body]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options: any = {}): FetchArgs {
+            // verify required parameter 'courseId' is not null or undefined
+            if (courseId === null || courseId === undefined) {
+                throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling coursesCreateCourseBasedOn.');
+            }
+            const localVarPath = `/api/Courses/createBasedOn/{courseId}`
+                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarHeaderParameter['Content-Type'] = 'application/json-patch+json';
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            localVarUrlObj.search = null;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"CreateCourseViewModel" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {number} courseId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4552,42 +4593,6 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
         /**
          *
          * @param {number} courseId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        coursesRecreateCourse(courseId: number, options: any = {}): FetchArgs {
-            // verify required parameter 'courseId' is not null or undefined
-            if (courseId === null || courseId === undefined) {
-                throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling coursesRecreateCourse.');
-            }
-            const localVarPath = `/api/Courses/recreate/{courseId}`
-                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)));
-            const localVarUrlObj = url.parse(localVarPath, true);
-            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication Bearer required
-            if (configuration && configuration.apiKey) {
-                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-                    ? configuration.apiKey("Authorization")
-                    : configuration.apiKey;
-                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
-            }
-
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            localVarUrlObj.search = null;
-            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-
-            return {
-                url: url.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {number} courseId
          * @param {string} studentId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4772,6 +4777,25 @@ export const CoursesApiFp = function(configuration?: Configuration) {
         /**
          *
          * @param {number} courseId
+         * @param {CreateCourseViewModel} [body]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<number> {
+            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).coursesCreateCourseBasedOn(courseId, body, options);
+            return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         *
+         * @param {number} courseId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4935,24 +4959,6 @@ export const CoursesApiFp = function(configuration?: Configuration) {
         /**
          *
          * @param {number} courseId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        coursesRecreateCourse(courseId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<number> {
-            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).coursesRecreateCourse(courseId, options);
-            return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
-                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-                    if (response.status >= 200 && response.status < 300) {
-                        return response.json();
-                    } else {
-                        throw response;
-                    }
-                });
-            };
-        },
-        /**
-         *
-         * @param {number} courseId
          * @param {string} studentId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5047,6 +5053,16 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
         /**
          *
          * @param {number} courseId
+         * @param {CreateCourseViewModel} [body]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options?: any) {
+            return CoursesApiFp(configuration).coursesCreateCourseBasedOn(courseId, body, options)(fetch, basePath);
+        },
+        /**
+         *
+         * @param {number} courseId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -5129,15 +5145,6 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
         /**
          *
          * @param {number} courseId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        coursesRecreateCourse(courseId: number, options?: any) {
-            return CoursesApiFp(configuration).coursesRecreateCourse(courseId, options)(fetch, basePath);
-        },
-        /**
-         *
-         * @param {number} courseId
          * @param {string} studentId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5207,6 +5214,18 @@ export class CoursesApi extends BaseAPI {
      */
     public coursesCreateCourse(body?: CreateCourseViewModel, options?: any) {
         return CoursesApiFp(this.configuration).coursesCreateCourse(body, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     *
+     * @param {number} courseId
+     * @param {CreateCourseViewModel} [body]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CoursesApi
+     */
+    public coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options?: any) {
+        return CoursesApiFp(this.configuration).coursesCreateCourseBasedOn(courseId, body, options)(this.fetch, this.basePath);
     }
 
     /**
@@ -5307,17 +5326,6 @@ export class CoursesApi extends BaseAPI {
      */
     public coursesGetMentorWorkspace(courseId: number, mentorId: string, options?: any) {
         return CoursesApiFp(this.configuration).coursesGetMentorWorkspace(courseId, mentorId, options)(this.fetch, this.basePath);
-    }
-
-    /**
-     *
-     * @param {number} courseId
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof CoursesApi
-     */
-    public coursesRecreateCourse(courseId: number, options?: any) {
-        return CoursesApiFp(this.configuration).coursesRecreateCourse(courseId, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -1094,6 +1094,12 @@ export interface HomeworkTaskViewModel {
     publicationDateNotSet?: boolean;
     /**
      *
+     * @type {boolean}
+     * @memberof HomeworkTaskViewModel
+     */
+    deadlineDateNotSet?: boolean;
+    /**
+     *
      * @type {number}
      * @memberof HomeworkTaskViewModel
      */
@@ -1209,6 +1215,12 @@ export interface HomeworkViewModel {
      * @memberof HomeworkViewModel
      */
     publicationDateNotSet?: boolean;
+    /**
+     *
+     * @type {boolean}
+     * @memberof HomeworkViewModel
+     */
+    deadlineDateNotSet?: boolean;
     /**
      *
      * @type {number}

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -4552,6 +4552,42 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
         /**
          *
          * @param {number} courseId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        coursesRecreateCourse(courseId: number, options: any = {}): FetchArgs {
+            // verify required parameter 'courseId' is not null or undefined
+            if (courseId === null || courseId === undefined) {
+                throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling coursesRecreateCourse.');
+            }
+            const localVarPath = `/api/Courses/recreate/{courseId}`
+                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer required
+            if (configuration && configuration.apiKey) {
+                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
+                    ? configuration.apiKey("Authorization")
+                    : configuration.apiKey;
+                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            localVarUrlObj.search = null;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {number} courseId
          * @param {string} studentId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4899,6 +4935,24 @@ export const CoursesApiFp = function(configuration?: Configuration) {
         /**
          *
          * @param {number} courseId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        coursesRecreateCourse(courseId: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<number> {
+            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).coursesRecreateCourse(courseId, options);
+            return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response.json();
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
+         *
+         * @param {number} courseId
          * @param {string} studentId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5075,6 +5129,15 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
         /**
          *
          * @param {number} courseId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        coursesRecreateCourse(courseId: number, options?: any) {
+            return CoursesApiFp(configuration).coursesRecreateCourse(courseId, options)(fetch, basePath);
+        },
+        /**
+         *
+         * @param {number} courseId
          * @param {string} studentId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5244,6 +5307,17 @@ export class CoursesApi extends BaseAPI {
      */
     public coursesGetMentorWorkspace(courseId: number, mentorId: string, options?: any) {
         return CoursesApiFp(this.configuration).coursesGetMentorWorkspace(courseId, mentorId, options)(this.fetch, this.basePath);
+    }
+
+    /**
+     *
+     * @param {number} courseId
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CoursesApi
+     */
+    public coursesRecreateCourse(courseId: number, options?: any) {
+        return CoursesApiFp(this.configuration).coursesRecreateCourse(courseId, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -494,6 +494,12 @@ export interface CreateCourseViewModel {
      * @memberof CreateCourseViewModel
      */
     isOpen: boolean;
+    /**
+     *
+     * @type {number}
+     * @memberof CreateCourseViewModel
+     */
+    baseCourseId?: number;
 }
 /**
  *
@@ -4223,47 +4229,6 @@ export const CoursesApiFetchParamCreator = function (configuration?: Configurati
         /**
          *
          * @param {number} courseId
-         * @param {CreateCourseViewModel} [body]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options: any = {}): FetchArgs {
-            // verify required parameter 'courseId' is not null or undefined
-            if (courseId === null || courseId === undefined) {
-                throw new RequiredError('courseId','Required parameter courseId was null or undefined when calling coursesCreateCourseBasedOn.');
-            }
-            const localVarPath = `/api/Courses/createBasedOn/{courseId}`
-                .replace(`{${"courseId"}}`, encodeURIComponent(String(courseId)));
-            const localVarUrlObj = url.parse(localVarPath, true);
-            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication Bearer required
-            if (configuration && configuration.apiKey) {
-                const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-                    ? configuration.apiKey("Authorization")
-                    : configuration.apiKey;
-                localVarHeaderParameter["Authorization"] = localVarApiKeyValue;
-            }
-
-            localVarHeaderParameter['Content-Type'] = 'application/json-patch+json';
-
-            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            localVarUrlObj.search = null;
-            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-            const needsSerialization = (<any>"CreateCourseViewModel" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
-
-            return {
-                url: url.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {number} courseId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4777,25 +4742,6 @@ export const CoursesApiFp = function(configuration?: Configuration) {
         /**
          *
          * @param {number} courseId
-         * @param {CreateCourseViewModel} [body]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<number> {
-            const localVarFetchArgs = CoursesApiFetchParamCreator(configuration).coursesCreateCourseBasedOn(courseId, body, options);
-            return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
-                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-                    if (response.status >= 200 && response.status < 300) {
-                        return response.json();
-                    } else {
-                        throw response;
-                    }
-                });
-            };
-        },
-        /**
-         *
-         * @param {number} courseId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -5053,16 +4999,6 @@ export const CoursesApiFactory = function (configuration?: Configuration, fetch?
         /**
          *
          * @param {number} courseId
-         * @param {CreateCourseViewModel} [body]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options?: any) {
-            return CoursesApiFp(configuration).coursesCreateCourseBasedOn(courseId, body, options)(fetch, basePath);
-        },
-        /**
-         *
-         * @param {number} courseId
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -5214,18 +5150,6 @@ export class CoursesApi extends BaseAPI {
      */
     public coursesCreateCourse(body?: CreateCourseViewModel, options?: any) {
         return CoursesApiFp(this.configuration).coursesCreateCourse(body, options)(this.fetch, this.basePath);
-    }
-
-    /**
-     *
-     * @param {number} courseId
-     * @param {CreateCourseViewModel} [body]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof CoursesApi
-     */
-    public coursesCreateCourseBasedOn(courseId: number, body?: CreateCourseViewModel, options?: any) {
-        return CoursesApiFp(this.configuration).coursesCreateCourseBasedOn(courseId, body, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/hwproj.front/src/api/api.ts
+++ b/hwproj.front/src/api/api.ts
@@ -1088,6 +1088,12 @@ export interface HomeworkTaskViewModel {
     publicationDate?: Date;
     /**
      *
+     * @type {boolean}
+     * @memberof HomeworkTaskViewModel
+     */
+    publicationDateNotSet?: boolean;
+    /**
+     *
      * @type {number}
      * @memberof HomeworkTaskViewModel
      */
@@ -1197,6 +1203,12 @@ export interface HomeworkViewModel {
      * @memberof HomeworkViewModel
      */
     publicationDate?: Date;
+    /**
+     *
+     * @type {boolean}
+     * @memberof HomeworkViewModel
+     */
+    publicationDateNotSet?: boolean;
     /**
      *
      * @type {number}

--- a/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
+++ b/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
@@ -38,7 +38,7 @@ const PublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
 
     const [state, setState] = useState<IDateFieldsState>(() => {
         const publicationDate =
-            props.publicationDate && !Utils.isMaxAllowedDate(props.publicationDate)
+            props.publicationDate && !Utils.isMaxSupportedDate(props.publicationDate)
                 ? props.publicationDate
                 : getInitialPublicationDate()
 

--- a/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
+++ b/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
@@ -38,7 +38,7 @@ const PublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
 
     const [state, setState] = useState<IDateFieldsState>(() => {
         const publicationDate =
-            props.publicationDate && props.publicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+            props.publicationDate && !Utils.isMaxAllowedDate(props.publicationDate)
                 ? props.publicationDate
                 : getInitialPublicationDate()
 

--- a/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
+++ b/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
@@ -37,10 +37,7 @@ const PublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
     }
 
     const [state, setState] = useState<IDateFieldsState>(() => {
-        const publicationDate =
-            props.publicationDate && !Utils.isMaxSupportedDate(props.publicationDate)
-                ? props.publicationDate
-                : getInitialPublicationDate()
+        const publicationDate = props.publicationDate || getInitialPublicationDate()
 
         const deadlineDate =
             props.hasDeadline

--- a/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
+++ b/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
@@ -37,18 +37,20 @@ const PublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
     }
 
     const [state, setState] = useState<IDateFieldsState>(() => {
-        const publicationDate = props.publicationDate === undefined
-            ? getInitialPublicationDate()
-            : props.publicationDate
+        const publicationDate =
+            props.publicationDate && props.publicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+                ? props.publicationDate
+                : getInitialPublicationDate()
+
+        const deadlineDate =
+            props.hasDeadline
+                ? props.deadlineDate || props.autoCalculatedDeadline || getInitialDeadlineDate(publicationDate)
+                : undefined
 
         return {
             hasDeadline: props.hasDeadline,
-            publicationDate: props.publicationDate === undefined
-                ? getInitialPublicationDate()
-                : props.publicationDate,
-            deadlineDate: props.hasDeadline
-                ? props.deadlineDate || props.autoCalculatedDeadline || getInitialDeadlineDate(publicationDate)
-                : undefined,
+            publicationDate: publicationDate,
+            deadlineDate: deadlineDate,
             isDeadlineStrict: props.isDeadlineStrict,
         }
     });

--- a/hwproj.front/src/components/Courses/AddCourseInfo.tsx
+++ b/hwproj.front/src/components/Courses/AddCourseInfo.tsx
@@ -1,30 +1,46 @@
-import {FC, ChangeEvent} from "react"
+import {FC, Dispatch, SetStateAction, ChangeEvent} from "react"
 import {
   Grid,
   TextField,
   Button,
 } from "@material-ui/core";
 import {LoadingButton} from "@mui/lab";
+import {ICreateCourseState} from "./ICreateCourseState";
 
 interface IAddCourseInfoProps {
-  courseName: string;
-  groupName: string;
-  courseIsLoading: boolean;
-  setCourseName: (name: string) => void;
-  setGroupName: (name: string) => void;
-  handleBack: () => void;
+  state: ICreateCourseState;
+  setState: Dispatch<SetStateAction<ICreateCourseState>>;
 }
 
 const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
+  const state = props.state
+
   const handleCourseNameChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     e.persist()
-    props.setCourseName(e.target.value)
+    props.setState((prevState) => ({
+      ...prevState,
+      courseName: e.target.value,
+    }))
   }
 
   const handleGroupNameChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     e.persist()
-    props.setGroupName(e.target.value)
+    props.setState((prevState) => ({
+      ...prevState,
+      groupName: e.target.value,
+    }))
   }
+
+  const handleBack = () =>
+    props.setState((prevState) => {
+      const newSkippedSteps = prevState.skippedSteps
+      newSkippedSteps.delete(prevState.activeStep - 1)
+      return ({
+        ...prevState,
+        activeStep: prevState.activeStep - 1,
+        skippedSteps: newSkippedSteps,
+      })
+    })
 
   return (
     <Grid container spacing={2}>
@@ -34,7 +50,7 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
           label="Название курса"
           variant="outlined"
           fullWidth
-          value={props.courseName}
+          value={state.courseName}
           onChange={handleCourseNameChange}
         />
       </Grid>
@@ -43,16 +59,16 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
           label="Номер группы"
           variant="outlined"
           fullWidth
-          value={props.groupName}
+          value={state.groupName}
           onChange={handleGroupNameChange}
         />
       </Grid>
-      <Grid item style={{ marginTop: 8, display: "flex", justifyContent: "space-between", width: "100%" }}>
+      <Grid item xs={12} style={{ marginTop: 8, display: "flex", justifyContent: "space-between" }}>
         <Button
           variant="outlined"
           color="primary"
           size="large"
-          onClick={props.handleBack}
+          onClick={handleBack}
         >
           Назад
         </Button>
@@ -61,7 +77,8 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
           variant="contained"
           size="large"
           style={{ color: "white", backgroundColor: "#3f51b5" }}
-          loading={props.courseIsLoading}
+          disabled={!state.courseName}
+          loading={state.courseIsLoading}
         >
           Создать курс
         </LoadingButton>

--- a/hwproj.front/src/components/Courses/AddCourseInfo.tsx
+++ b/hwproj.front/src/components/Courses/AddCourseInfo.tsx
@@ -76,7 +76,7 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
           type="submit"
           variant="contained"
           size="large"
-          style={{ color: "white", backgroundColor: "#3f51b5" }}
+          sx={{ background: "#3f51b5", color: "white" }}
           disabled={!state.courseName}
           loading={state.courseIsLoading}
         >

--- a/hwproj.front/src/components/Courses/AddCourseInfo.tsx
+++ b/hwproj.front/src/components/Courses/AddCourseInfo.tsx
@@ -65,9 +65,9 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
       </Grid>
       <Grid item xs={12} style={{ marginTop: 8, display: "flex", justifyContent: "space-between" }}>
         <Button
-          variant="outlined"
-          color="primary"
+          variant="text"
           size="large"
+          hidden={!state.baseCourses?.length}
           onClick={handleBack}
         >
           Назад
@@ -76,7 +76,7 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
           type="submit"
           variant="contained"
           size="large"
-          sx={{ background: "#3f51b5", color: "white" }}
+          sx={{ marginLeft: "auto", background: "#3f51b5", color: "white" }}
           disabled={!state.courseName}
           loading={state.courseIsLoading}
         >

--- a/hwproj.front/src/components/Courses/AddCourseInfo.tsx
+++ b/hwproj.front/src/components/Courses/AddCourseInfo.tsx
@@ -1,18 +1,13 @@
-import {FC, Dispatch, SetStateAction, ChangeEvent} from "react"
+import {FC, ChangeEvent} from "react"
 import {
   Grid,
   TextField,
   Button,
 } from "@material-ui/core";
 import {LoadingButton} from "@mui/lab";
-import {ICreateCourseState} from "./ICreateCourseState";
+import {IStepComponentProps} from "./ICreateCourseState";
 
-interface IAddCourseInfoProps {
-  state: ICreateCourseState;
-  setState: Dispatch<SetStateAction<ICreateCourseState>>;
-}
-
-const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
+const AddCourseInfo: FC<IStepComponentProps> = (props) => {
   const state = props.state
 
   const handleCourseNameChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -76,7 +71,11 @@ const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
           type="submit"
           variant="contained"
           size="large"
-          sx={{ marginLeft: "auto", background: "#3f51b5", color: "white" }}
+          sx={{
+            marginLeft: "auto",
+            background: "#3f51b5",
+            ":hover": { background: "#383c9c" },
+          }}
           disabled={!state.courseName}
           loading={state.courseIsLoading}
         >

--- a/hwproj.front/src/components/Courses/AddCourseInfo.tsx
+++ b/hwproj.front/src/components/Courses/AddCourseInfo.tsx
@@ -1,0 +1,73 @@
+import {FC, ChangeEvent} from "react"
+import {
+  Grid,
+  TextField,
+  Button,
+} from "@material-ui/core";
+import {LoadingButton} from "@mui/lab";
+
+interface IAddCourseInfoProps {
+  courseName: string;
+  groupName: string;
+  courseIsLoading: boolean;
+  setCourseName: (name: string) => void;
+  setGroupName: (name: string) => void;
+  handleBack: () => void;
+}
+
+const AddCourseInfo: FC<IAddCourseInfoProps> = (props: IAddCourseInfoProps) => {
+  const handleCourseNameChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    e.persist()
+    props.setCourseName(e.target.value)
+  }
+
+  const handleGroupNameChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    e.persist()
+    props.setGroupName(e.target.value)
+  }
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <TextField
+          required
+          label="Название курса"
+          variant="outlined"
+          fullWidth
+          value={props.courseName}
+          onChange={handleCourseNameChange}
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <TextField
+          label="Номер группы"
+          variant="outlined"
+          fullWidth
+          value={props.groupName}
+          onChange={handleGroupNameChange}
+        />
+      </Grid>
+      <Grid item style={{ marginTop: 8, display: "flex", justifyContent: "space-between", width: "100%" }}>
+        <Button
+          variant="outlined"
+          color="primary"
+          size="large"
+          onClick={props.handleBack}
+        >
+          Назад
+        </Button>
+        <LoadingButton
+          type="submit"
+          variant="contained"
+          size="large"
+          style={{ color: "white", backgroundColor: "#3f51b5" }}
+          loading={props.courseIsLoading}
+        >
+          Создать курс
+        </LoadingButton>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default AddCourseInfo

--- a/hwproj.front/src/components/Courses/Course.tsx
+++ b/hwproj.front/src/components/Courses/Course.tsx
@@ -260,12 +260,6 @@ const Course: React.FC<ICourseProps> = (props: ICourseProps) => {
         );
     }
 
-    const recreateCourse = async () => {
-        const newCourseId = await ApiSingleton.coursesApi.coursesRecreateCourse(+courseId!)
-        navigate("/courses")
-        navigate(`/courses/${newCourseId}/editHomeworks`)
-    }
-
     if (isFound) {
         return (
             <div className="container">
@@ -306,18 +300,6 @@ const Course: React.FC<ICourseProps> = (props: ICourseProps) => {
                             </Grid>
                             <Grid item>
                                 <Grid container alignItems="center" justifyContent="flex-end">
-                                    {isCourseMentor && isLecturer && !isReadingMode &&
-                                        <Button
-                                            style={{marginRight: '16px'}}
-                                            full-width
-                                            size="medium"
-                                            variant="outlined"
-                                            color="primary"
-                                            onClick={recreateCourse}
-                                        >
-                                            Пересоздать курс
-                                        </Button>
-                                    }
                                     <Grid item>
                                         <MentorsList mentors={mentors}/>
                                     </Grid>

--- a/hwproj.front/src/components/Courses/Course.tsx
+++ b/hwproj.front/src/components/Courses/Course.tsx
@@ -260,6 +260,12 @@ const Course: React.FC<ICourseProps> = (props: ICourseProps) => {
         );
     }
 
+    const recreateCourse = async () => {
+        const newCourseId = await ApiSingleton.coursesApi.coursesRecreateCourse(+courseId!)
+        navigate("/courses")
+        navigate(`/courses/${newCourseId}/editHomeworks`)
+    }
+
     if (isFound) {
         return (
             <div className="container">
@@ -300,6 +306,18 @@ const Course: React.FC<ICourseProps> = (props: ICourseProps) => {
                             </Grid>
                             <Grid item>
                                 <Grid container alignItems="center" justifyContent="flex-end">
+                                    {isCourseMentor && isLecturer && !isReadingMode &&
+                                        <Button
+                                            style={{marginRight: '16px'}}
+                                            full-width
+                                            size="medium"
+                                            variant="outlined"
+                                            color="primary"
+                                            onClick={recreateCourse}
+                                        >
+                                            Пересоздать курс
+                                        </Button>
+                                    }
                                     <Grid item>
                                         <MentorsList mentors={mentors}/>
                                     </Grid>

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -129,13 +129,13 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
 
         if (entity.publicationDateNotSet) return (
             <Alert severity="warning">
-                {"Дата публикации задания не выставлена"}
+                {"Не выставлена дата публикации"}
             </Alert>
         )
 
         if (entity.hasDeadline && !entity.deadlineDate) return (
             <Alert severity="warning">
-                {"Дата дедлайна не выставлена"}
+                {"Не выставлена дата дедлайна"}
             </Alert>
         )
 

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -125,7 +125,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
     }
 
     const hasSetPublicationDate = (entity: HomeworkViewModel | HomeworkTaskViewModel) =>
-        !Utils.isMaxAllowedDate(new Date(entity.publicationDate!))
+        !Utils.isMaxSupportedDate(new Date(entity.publicationDate!))
 
     const getAlert = (entity: HomeworkViewModel | HomeworkTaskViewModel) => {
         if (!entity.isDeferred) return null

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -116,10 +116,8 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
             .forEach(x => taskSolutionsMap.set(x.id!, x.solution!))
     }
 
-    const showWarningsForEntity = (entity: HomeworkViewModel | HomeworkTaskViewModel) => {
-        const deadlineDateNotSet = entity.hasDeadline && !entity.deadlineDate
-        return isMentor && (entity.publicationDateNotSet || deadlineDateNotSet)
-    }
+    const showWarningsForEntity = (entity: HomeworkViewModel | HomeworkTaskViewModel) =>
+        isMentor && (entity.publicationDateNotSet || entity.hasDeadline && entity.deadlineDateNotSet)
 
     const renderTaskStatus = (task: HomeworkTaskViewModel) => {
         if (taskSolutionsMap.has(task.id!)) {
@@ -165,7 +163,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
             </Alert>
         )
 
-        if (isMentor && entity.hasDeadline && !entity.deadlineDate) return (
+        if (isMentor && entity.hasDeadline && entity.deadlineDateNotSet) return (
             <Alert severity="warning">
                 {"Не выставлена дата дедлайна"}
             </Alert>
@@ -298,7 +296,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
                             }}>
                             <Typography variant="h6" style={{fontSize: 18}} align={"center"}
                                         color={x.isDeferred ? "textSecondary" : "textPrimary"}>
-                                {showWarningsForEntity(x) && <div>⚠️<br/></div>}
+                                {showWarningsForEntity(x) && <div style={{ fontSize: 16 }}>⚠️<br/></div>}
                                 {x.title}{getTip(x)}
                             </Typography>
                             {x.isDeferred && !x.publicationDateNotSet &&
@@ -327,11 +325,13 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
                             }}
                             style={{...getStyle(false, t.id!), marginBottom: 2}}
                             sx={{":hover": hoveredItemStyle}}>
-                            <TimelineOppositeContent color="textSecondary">
-                                {t.deadlineDate ? renderDate(t.deadlineDate) : ""}
-                                <br/>
-                                {t.deadlineDate ? renderTime(t.deadlineDate) : ""}
-                            </TimelineOppositeContent>
+                            {!t.deadlineDateNotSet &&
+                                <TimelineOppositeContent color="textSecondary">
+                                    {t.deadlineDate ? renderDate(t.deadlineDate) : ""}
+                                    <br/>
+                                    {t.deadlineDate ? renderTime(t.deadlineDate) : ""}
+                                </TimelineOppositeContent>
+                            }
                             <TimelineSeparator>
                                 {renderTaskStatus(t)}
                                 <TimelineConnector/>

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -188,14 +188,14 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
                             onMount={onSelectedItemMount}
                             onUpdate={update => {
                                 props.onHomeworkUpdate(update)
-                                if (update.isDeleted) {
-                                    setState({
+                                if (update.isDeleted) 
+                                    setState((prevState) => ({
+                                        ...prevState,
                                         selectedItem: {
                                             isHomework: true,
                                             id: undefined
                                         }
-                                    })
-                                }
+                                    }))
                             }}/>
                     </Card>
                 </Grid>
@@ -214,15 +214,15 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
                                             initialEditMode={initialEditMode}
                                             onMount={onSelectedItemMount}
                                             onUpdate={update => {
-                                                props.onHomeworkUpdate(update)
-                                                if (update.isDeleted) {
-                                                    setState({
+                                                props.onTaskUpdate(update)
+                                                if (update.isDeleted)
+                                                    setState((prevState) => ({
+                                                        ...prevState,
                                                         selectedItem: {
                                                             isHomework: true,
-                                                            id: undefined
+                                                            id: homework!.id
                                                         }
-                                                    })
-                                                }
+                                                    }))
                                             }}
                                             toEditHomework={() => toEditHomework(homework!)}/>
                     {!props.isMentor && props.isStudentAccepted && < CardActions>

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -124,13 +124,10 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
         return <TimelineDot variant={"outlined"}/>
     }
 
-    const hasSetPublicationDate = (entity: HomeworkViewModel | HomeworkTaskViewModel) =>
-        !Utils.isMaxSupportedDate(new Date(entity.publicationDate!))
-
     const getAlert = (entity: HomeworkViewModel | HomeworkTaskViewModel) => {
         if (!entity.isDeferred) return null
 
-        if (!hasSetPublicationDate(entity)) return (
+        if (entity.publicationDateNotSet) return (
             <Alert severity="warning">
                 {"Дата публикации задания не выставлена"}
             </Alert>
@@ -261,7 +258,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
                                         color={x.isDeferred ? "textSecondary" : "textPrimary"}>
                                 {x.title}{getTip(x)}
                             </Typography>
-                            {x.isDeferred && hasSetPublicationDate(x) &&
+                            {x.isDeferred && !x.publicationDateNotSet &&
                                 <Typography style={{fontSize: "14px"}} align={"center"}>
                                     {"🕘 " + renderDate(x.publicationDate!) + " " + renderTime(x.publicationDate!)}
                                 </Typography>}

--- a/hwproj.front/src/components/Courses/CourseExperimental.tsx
+++ b/hwproj.front/src/components/Courses/CourseExperimental.tsx
@@ -24,6 +24,7 @@ import {getTip} from "../Common/HomeworkTags";
 import FileInfoConverter from "components/Utils/FileInfoConverter";
 import CourseHomeworkExperimental from "components/Homeworks/CourseHomeworkExperimental";
 import CourseTaskExperimental from "../Tasks/CourseTaskExperimental";
+import Utils from "services/Utils";
 
 interface ICourseExperimentalProps {
     homeworks: HomeworkViewModel[]
@@ -123,9 +124,25 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
         return <TimelineDot variant={"outlined"}/>
     }
 
+    const hasSetPublicationDate = (entity: HomeworkViewModel | HomeworkTaskViewModel) =>
+        !Utils.isMaxAllowedDate(new Date(entity.publicationDate!))
+
     const getAlert = (entity: HomeworkViewModel | HomeworkTaskViewModel) => {
         if (!entity.isDeferred) return null
-        return <Alert severity={"info"}
+
+        if (!hasSetPublicationDate(entity)) return (
+            <Alert severity="warning">
+                {"Дата публикации задания не выставлена"}
+            </Alert>
+        )
+
+        if (entity.hasDeadline && !entity.deadlineDate) return (
+            <Alert severity="warning">
+                {"Дата дедлайна не выставлена"}
+            </Alert>
+        )
+
+        return <Alert severity="info"
                       style={{marginTop: 2}}
                       action={
                           <Button
@@ -244,7 +261,7 @@ const CourseExperimental: FC<ICourseExperimentalProps> = (props) => {
                                         color={x.isDeferred ? "textSecondary" : "textPrimary"}>
                                 {x.title}{getTip(x)}
                             </Typography>
-                            {x.isDeferred &&
+                            {x.isDeferred && hasSetPublicationDate(x) &&
                                 <Typography style={{fontSize: "14px"}} align={"center"}>
                                     {"🕘 " + renderDate(x.publicationDate!) + " " + renderTime(x.publicationDate!)}
                                 </Typography>}

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -55,10 +55,11 @@ const CreateCourse: FC = () => {
   const navigate = useNavigate()
   const {enqueueSnackbar} = useSnackbar()
 
-  const toNextStep = () =>
+  const skipCurrentStep = () =>
     setState((prevState) => ({
       ...prevState,
       activeStep: prevState.activeStep + 1,
+      skippedSteps: prevState.skippedSteps.add(prevState.activeStep),
     }))
 
   const setBaseCourses = (courses?: CoursePreviewView[]) =>
@@ -77,11 +78,11 @@ const CreateCourse: FC = () => {
     const loadBaseCourses = async () => {
       try {
         const userCourses = await ApiSingleton.coursesApi.coursesGetAllUserCourses()
-        if (!userCourses.length) toNextStep()
+        if (!userCourses.length) skipCurrentStep()
         setBaseCourses(userCourses)
       }
       catch (e) {
-        toNextStep()
+        skipCurrentStep()
         setBaseCourses([])
         console.error("Ошибка при загрузке курсов лектора:", e)
         enqueueSnackbar("Не удалось загрузить существующие курсы", {variant: "warning", autoHideDuration: 4000})

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -9,7 +9,6 @@ import {FC, FormEvent, useState, useEffect} from "react";
 import ApiSingleton from "../../api/ApiSingleton";
 import {CoursePreviewView} from "api";
 import "./Styles/CreateCourse.css";
-import GroupIcon from "@material-ui/icons/Group";
 import {makeStyles} from "@material-ui/core/styles";
 import Container from "@material-ui/core/Container";
 import {useNavigate} from "react-router-dom";
@@ -30,9 +29,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-  },
-  avatar: {
-    margin: theme.spacing(1),
   },
   form: {
     marginTop: theme.spacing(3),
@@ -154,11 +150,6 @@ const CreateCourse: FC = () => {
   return state.baseCourses ? (
     <Container component="main" maxWidth="sm">
       <div className={classes.paper}>
-        <GroupIcon
-          fontSize="large"
-          style={{ color: "white", backgroundColor: "#ecb50d" }}
-          className={classes.avatar}
-        />
         <Typography component="h1" variant="h5">
           Создать курс
         </Typography>

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -100,12 +100,11 @@ const CreateCourse: FC = () => {
       name: course.name,
       groupName: course.groupName,
       isOpen: true,
+      baseCourseId: (course.baseCourseId && +course.baseCourseId) || undefined
     }
     try {
       setCourseIsLoading()
-      const courseId = course.baseCourseId !== undefined
-        ? await ApiSingleton.coursesApi.coursesCreateCourseBasedOn(+course.baseCourseId, courseViewModel)
-        : await ApiSingleton.coursesApi.coursesCreateCourse(courseViewModel) 
+      const courseId = await ApiSingleton.coursesApi.coursesCreateCourse(courseViewModel)
       setCourse((prevState) => ({
         ...prevState,
         isLoading: false,

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -20,10 +20,10 @@ import { LoadingButton } from "@mui/lab";
 interface ICreateCourseState {
   name: string;
   groupName?: string;
-  baseCourseId?: number;
+  baseCourseId?: string;
   courseId: string;
-  errors: string[];
   isLoading: boolean;
+  errors: string[];
 }
 
 interface IBaseCoursesState {
@@ -56,8 +56,8 @@ const CreateCourse: FC = () => {
     name: "",
     groupName: "",
     courseId: "",
-    errors: [],
     isLoading: false,
+    errors: [],
   })
 
   const [baseCourses, setBaseCourses] = useState<IBaseCoursesState>({
@@ -105,7 +105,7 @@ const CreateCourse: FC = () => {
     try {
       setCourseIsLoading()
       const courseId = course.baseCourseId !== undefined
-        ? await ApiSingleton.coursesApi.coursesCreateCourseBasedOn(course.baseCourseId, courseViewModel)
+        ? await ApiSingleton.coursesApi.coursesCreateCourseBasedOn(Number(course.baseCourseId), courseViewModel)
         : await ApiSingleton.coursesApi.coursesCreateCourse(courseViewModel) 
       setCourse((prevState) => ({
         ...prevState,
@@ -197,17 +197,20 @@ const CreateCourse: FC = () => {
                         e.persist()
                         setCourse((prevState) => ({
                           ...prevState,
-                          baseCourseId: Number(e.target.value)
+                          baseCourseId: e.target.value || undefined
                         }))
                       }}
                     >
+                      <MenuItem value="">
+                        <Typography style={{fontSize: "20px"}}>Курс с нуля</Typography>
+                      </MenuItem>
                       {baseCourses.courses.map(course =>
                         <MenuItem value={course.id!}>
                           <Typography style={{fontSize: "20px"}}>
                             {NameBuilder.getCourseFullName(course.name!, course.groupName)}
                           </Typography>
                         </MenuItem>
-                      )}
+                      ).toReversed()}
                     </TextField>
                 </Grid>
               }

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -112,16 +112,18 @@ const CreateCourse: FC = () => {
   const stepIsCompleted = (step: CreateCourseStep) =>
     step < state.activeStep && !state.skippedSteps.has(step)
 
-  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    const baseCourse = state.baseCourseIndex !== undefined
+  const getBaseCourse = () =>
+    state.baseCourseIndex !== undefined
       ? state.baseCourses![state.baseCourseIndex]
       : undefined
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
     const courseViewModel = {
       name: state.courseName,
       groupName: state.groupName,
       isOpen: true,
-      baseCourseId: baseCourse?.id,
+      baseCourseId: getBaseCourse()?.id,
     }
     try {
       setCourseIsLoading(true)
@@ -162,7 +164,7 @@ const CreateCourse: FC = () => {
             {stepLabels.map((label, step) => {
               const optionalLabel = stepIsOptional(step) ? (
                 <Typography variant="caption">
-                  Опционально
+                  Необязательно
                 </Typography>
               ) : undefined
               return (

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -5,6 +5,7 @@ import {
   Typography,
   Grid,
   MenuItem,
+  CircularProgress,
 } from "@material-ui/core";
 import ApiSingleton from "../../api/ApiSingleton";
 import './Styles/CreateCourse.css';
@@ -27,6 +28,7 @@ interface ICreateCourseState {
 interface IBaseCoursesState {
   isLoaded: boolean;
   courses: CoursePreviewView[];
+  errors: string[];
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -59,6 +61,7 @@ const CreateCourse: FC = () => {
   const [baseCourses, setBaseCourses] = useState<IBaseCoursesState>({
     isLoaded: false,
     courses: [],
+    errors: [],
   })
 
   useEffect(() => {
@@ -68,16 +71,14 @@ const CreateCourse: FC = () => {
         setBaseCourses ({
           isLoaded: true,
           courses: userCourses,
+          errors: [],
         })
       } catch (e) {
         console.error("Ошибка при загрузке курсов лектора:", e)
-        setCourse((prevState) => ({
-          ...prevState,
-          errors: ['Не удалось загрузить курсы лектора']
-        }))
         setBaseCourses ({
           isLoaded: true,
           courses: [],
+          errors: ['Не удалось загрузить существующие курсы'],
         })
       }
     };
@@ -166,31 +167,38 @@ const CreateCourse: FC = () => {
                     }}
                 />
               </Grid>
-              <Grid item xs={12}>
-                <TextField
-                  select
-                  label="На основе существующего курса"
-                  variant="outlined"
-                  fullWidth
-                  value={course.baseCourseId}
-                  onChange={(e) =>
-                  {
-                    e.persist()
-                    setCourse((prevState) => ({
-                      ...prevState,
-                      baseCourseId: Number(e.target.value)
-                    }))
-                  }}
-                >
-                  {baseCourses.courses.map(course =>
-                    <MenuItem value={course.id!}>
-                      <Typography style={{fontSize: "20px"}}>
-                        {NameBuilder.getCourseFullName(course.name!, course.groupName)}
-                      </Typography>
-                    </MenuItem>
-                  )}
-                </TextField>
-              </Grid>
+              {!baseCourses.isLoaded &&
+                <Grid item xs={12} style={{display: "flex", justifyContent: "center"}}>
+                    <CircularProgress/>
+                </Grid>
+              }
+              {baseCourses.courses.length !== 0 &&
+                <Grid item xs={12}>
+                    <TextField
+                      select
+                      label="На основе существующего курса"
+                      variant="outlined"
+                      fullWidth
+                      value={course.baseCourseId}
+                      onChange={(e) =>
+                      {
+                        e.persist()
+                        setCourse((prevState) => ({
+                          ...prevState,
+                          baseCourseId: Number(e.target.value)
+                        }))
+                      }}
+                    >
+                      {baseCourses.courses.map(course =>
+                        <MenuItem value={course.id!}>
+                          <Typography style={{fontSize: "20px"}}>
+                            {NameBuilder.getCourseFullName(course.name!, course.groupName)}
+                          </Typography>
+                        </MenuItem>
+                      )}
+                    </TextField>
+                </Grid>
+              }
             </Grid>
             <Button
                 style={{ marginTop: '16px'}}

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -104,7 +104,7 @@ const CreateCourse: FC = () => {
     try {
       setCourseIsLoading()
       const courseId = course.baseCourseId !== undefined
-        ? await ApiSingleton.coursesApi.coursesCreateCourseBasedOn(Number(course.baseCourseId), courseViewModel)
+        ? await ApiSingleton.coursesApi.coursesCreateCourseBasedOn(+course.baseCourseId, courseViewModel)
         : await ApiSingleton.coursesApi.coursesCreateCourse(courseViewModel) 
       setCourse((prevState) => ({
         ...prevState,
@@ -217,10 +217,9 @@ const CreateCourse: FC = () => {
               }
             </Grid>
             <LoadingButton
-                style={{ marginTop: '16px'}}
+                style={{ marginTop: '16px', color: "white", backgroundColor: "#3f51b5" }}
                 fullWidth
                 variant="contained"
-                color="primary"
                 type="submit"
                 loading={course.isLoading}
             >

--- a/hwproj.front/src/components/Courses/CreateCourse.tsx
+++ b/hwproj.front/src/components/Courses/CreateCourse.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
   },
   form: {
     marginTop: theme.spacing(3),
-    width: '100%'
+    width: '100%',
   },
   button: {
     marginTop: theme.spacing(1),
@@ -51,6 +51,11 @@ const CreateCourse: FC = () => {
     groupName: "",
     courseIsLoading: false,
   })
+
+  const baseCourse =
+    state.baseCourses && state.baseCourseIndex !== undefined
+      ? state.baseCourses[state.baseCourseIndex]
+      : undefined
 
   const navigate = useNavigate()
   const {enqueueSnackbar} = useSnackbar()
@@ -85,7 +90,10 @@ const CreateCourse: FC = () => {
         skipCurrentStep()
         setBaseCourses([])
         console.error("Ошибка при загрузке курсов лектора:", e)
-        enqueueSnackbar("Не удалось загрузить существующие курсы", {variant: "warning", autoHideDuration: 4000})
+        enqueueSnackbar(
+          "Не удалось загрузить существующие курсы",
+          {variant: "warning", autoHideDuration: 4000},
+        )
       }
     };
 
@@ -112,18 +120,13 @@ const CreateCourse: FC = () => {
   const stepIsCompleted = (step: CreateCourseStep) =>
     step < state.activeStep && !state.skippedSteps.has(step)
 
-  const getBaseCourse = () =>
-    state.baseCourseIndex !== undefined
-      ? state.baseCourses![state.baseCourseIndex]
-      : undefined
-
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const courseViewModel = {
       name: state.courseName,
       groupName: state.groupName,
       isOpen: true,
-      baseCourseId: getBaseCourse()?.id,
+      baseCourseId: baseCourse?.id,
     }
     try {
       setCourseIsLoading(true)

--- a/hwproj.front/src/components/Courses/ICreateCourseState.tsx
+++ b/hwproj.front/src/components/Courses/ICreateCourseState.tsx
@@ -1,0 +1,27 @@
+import {CoursePreviewView} from "api";
+
+export enum CreateCourseStep {
+  SelectBaseCourseStep = 0,
+  AddCourseInfoStep = 1,
+}
+
+export const stepLabels = [
+  "Взять за основу существующий курс",
+  "Заполнить данные о курсе",
+]
+
+export const stepIsOptional = (step: CreateCourseStep) =>
+  step === CreateCourseStep.SelectBaseCourseStep
+
+export interface ICreateCourseState {
+  activeStep: CreateCourseStep;
+  skippedSteps: Set<CreateCourseStep>;
+
+  baseCourses?: CoursePreviewView[];
+  baseCourseIndex?: number;
+
+  courseName: string;
+  groupName: string;
+
+  courseIsLoading: boolean;
+}

--- a/hwproj.front/src/components/Courses/ICreateCourseState.tsx
+++ b/hwproj.front/src/components/Courses/ICreateCourseState.tsx
@@ -1,3 +1,4 @@
+import {Dispatch, SetStateAction} from "react"
 import {CoursePreviewView} from "api";
 
 export enum CreateCourseStep {
@@ -6,8 +7,8 @@ export enum CreateCourseStep {
 }
 
 export const stepLabels = [
-  "Выберите шаблон курса",
-  "Заполните данные курса",
+  "Выберите шаблон",
+  "Заполните данные",
 ]
 
 export const stepIsOptional = (step: CreateCourseStep) =>
@@ -24,4 +25,9 @@ export interface ICreateCourseState {
   groupName: string;
 
   courseIsLoading: boolean;
+}
+
+export interface IStepComponentProps {
+  state: ICreateCourseState;
+  setState: Dispatch<SetStateAction<ICreateCourseState>>;
 }

--- a/hwproj.front/src/components/Courses/ICreateCourseState.tsx
+++ b/hwproj.front/src/components/Courses/ICreateCourseState.tsx
@@ -6,8 +6,8 @@ export enum CreateCourseStep {
 }
 
 export const stepLabels = [
-  "Взять за основу существующий курс",
-  "Заполнить данные о курсе",
+  "Выберите шаблон курса",
+  "Заполните данные курса",
 ]
 
 export const stepIsOptional = (step: CreateCourseStep) =>

--- a/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
+++ b/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
@@ -80,9 +80,9 @@ const SelectBaseCourse: FC<IStepComponentProps> = (props) => {
       </Grid>
       <Grid item xs={12} style={{ marginTop: 8, display: "flex", justifyContent: "space-between" }}>
         {baseCourseId !== undefined &&
-          <Link to={`/courses/${baseCourseId}`}>
+          <Link to={`/courses/${baseCourseId}`} target="_blank" rel="noopener noreferrer">
             <Button variant="text" size="large">
-              Посмотреть курс
+              Открыть курс
             </Button>
           </Link>
         }

--- a/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
+++ b/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
@@ -1,4 +1,4 @@
-import {FC, Dispatch, SetStateAction, ChangeEvent} from "react"
+import {FC, ChangeEvent} from "react"
 import {
   Grid,
   Box,
@@ -7,21 +7,22 @@ import {
   MenuItem,
   Typography,
 } from "@material-ui/core";
-import {ICreateCourseState} from "./ICreateCourseState";
+import {Link} from "react-router-dom";
+import {IStepComponentProps} from "./ICreateCourseState";
 import NameBuilder from "../Utils/NameBuilder";
 
-interface ISelectBaseCourseProps {
-  state: ICreateCourseState;
-  setState: Dispatch<SetStateAction<ICreateCourseState>>;
-}
-
-const SelectBaseCourse: FC<ISelectBaseCourseProps> = (props: ISelectBaseCourseProps) => {
+const SelectBaseCourse: FC<IStepComponentProps> = (props) => {
   const state = props.state
+
   const baseCourses = state.baseCourses!
+
+  const baseCourseId = state.baseCourseIndex !== undefined
+    ? baseCourses[state.baseCourseIndex].id
+    : undefined
 
   const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     e.persist()
-    const index = e.target.value ? +e.target.value : undefined
+    const index = e.target.value as unknown as (number | undefined)
     props.setState((prevState) => ({
       ...prevState,
       baseCourseIndex: index,
@@ -57,11 +58,11 @@ const SelectBaseCourse: FC<ISelectBaseCourseProps> = (props: ISelectBaseCoursePr
           label="Базовый курс"
           fullWidth
           variant="outlined"
-          value={state.baseCourseIndex || ""}
+          value={state.baseCourseIndex !== undefined ? state.baseCourseIndex : ""}
           onChange={handleChange}
         >
           {!baseCourses.length &&
-            <MenuItem value="" key={null}>
+            <MenuItem value={undefined} key={undefined}>
               <Typography>
                 Базовых курсов не найдено &#128532;<br/>
                 Попробуйте создать курс с нуля
@@ -77,24 +78,33 @@ const SelectBaseCourse: FC<ISelectBaseCourseProps> = (props: ISelectBaseCoursePr
           ).reverse()}
         </TextField>
       </Grid>
-      <Grid item xs={12} style={{ marginTop: 8, display: "flex", justifyContent: "flex-end" }}>
-        <Button
-          variant="text"
-          size="large"
-          style={{ marginRight: 8 }}
-          onClick={handleSkip}
-        >
-          Пропустить
-        </Button>
-        <Button
-          variant="text"
-          color="primary"
-          size="large" 
-          disabled={state.baseCourseIndex === undefined}
-          onClick={handleNext}
-        >
-          Далее
-        </Button>
+      <Grid item xs={12} style={{ marginTop: 8, display: "flex", justifyContent: "space-between" }}>
+        {baseCourseId !== undefined &&
+          <Link to={`/courses/${baseCourseId}`}>
+            <Button variant="text" size="large">
+              Посмотреть курс
+            </Button>
+          </Link>
+        }
+        <Box style={{ marginLeft: "auto" }}>
+          <Button
+            variant="text"
+            size="large"
+            style={{ marginRight: 8 }}
+            onClick={handleSkip}
+          >
+            Пропустить
+          </Button>
+          <Button
+            variant="text"
+            color="primary"
+            size="large" 
+            disabled={state.baseCourseIndex === undefined}
+            onClick={handleNext}
+          >
+            Далее
+          </Button>
+        </Box>
       </Grid>
     </Grid>
   )

--- a/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
+++ b/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
@@ -87,7 +87,7 @@ const SelectBaseCourse: FC<ISelectBaseCourseProps> = (props: ISelectBaseCoursePr
           Пропустить
         </Button>
         <Button
-          variant="outlined"
+          variant="text"
           color="primary"
           size="large" 
           disabled={state.baseCourseIndex === undefined}

--- a/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
+++ b/hwproj.front/src/components/Courses/SelectBaseCourse.tsx
@@ -1,0 +1,80 @@
+import {FC, ChangeEvent} from "react"
+import {
+  Grid,
+  TextField,
+  Button,
+  MenuItem,
+  Typography,
+} from "@material-ui/core";
+import {CoursePreviewView} from "api";
+import NameBuilder from "../Utils/NameBuilder";
+
+interface ISelectBaseCourseProps {
+  baseCourses: CoursePreviewView[];
+  baseCourseIndex?: number;
+  setBaseCourseIndex: (index?: number) => void;
+  handleSkip: () => void;
+  handleNext: () => void;
+}
+
+const SelectBaseCourse: FC<ISelectBaseCourseProps> = (props: ISelectBaseCourseProps) => {
+  const baseCourses = props.baseCourses
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    e.persist()
+    const index = +e.target.value || undefined
+    props.setBaseCourseIndex(index)
+  }
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <TextField
+          select
+          label="Базовый курс"
+          fullWidth
+          variant="outlined"
+          value={props.baseCourseIndex}
+          onChange={handleChange}
+        >
+          {!baseCourses.length &&
+            <MenuItem>
+              <Typography>
+                Базовых курсов не найдено &#128532;<br/>
+                Попробуйте создать курс с нуля
+              </Typography>
+            </MenuItem>
+          }
+          {baseCourses.map((course, index) =>
+            <MenuItem value={index}>
+              <Typography style={{ fontSize: "20px" }}>
+                {NameBuilder.getCourseFullName(course.name!, course.groupName)}
+              </Typography>
+            </MenuItem>
+          ).reverse()}
+        </TextField>
+      </Grid>
+      <Grid item style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", width: "100%" }}>
+        <Button
+          variant="text"
+          color="inherit"
+          size="large"
+          style={{ marginRight: 8 }}
+          onClick={props.handleSkip}
+        >
+          Пропустить
+        </Button>
+        <Button
+          variant="outlined"
+          color="primary"
+          size="large" 
+          onClick={props.handleNext}
+        >
+          Далее
+        </Button>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default SelectBaseCourse

--- a/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
+++ b/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
@@ -64,9 +64,9 @@ const CourseHomeworkEditor: FC<{
         ? undefined
         : new Date(homework.publicationDate!)
 
-    const deadlineDate = homework.deadlineDate
-        ? new Date(homework.deadlineDate)
-        : undefined
+    const deadlineDate = homework.deadlineDateNotSet
+        ? undefined
+        : new Date(homework.deadlineDate!)
 
     const isPublished = !homework.isDeferred
     const changedTaskPublicationDates = homework.tasks!

--- a/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
+++ b/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
@@ -60,16 +60,18 @@ const CourseHomeworkEditor: FC<{
     const homeworkId = homework.id!
     const courseId = homework.courseId!
 
-    const deadlineDate = homework.deadlineDate ? new Date(homework.deadlineDate) : undefined
+    const publicationDate = homework.publicationDateNotSet
+        ? undefined
+        : new Date(homework.publicationDate!)
+
+    const deadlineDate = homework.deadlineDate
+        ? new Date(homework.deadlineDate)
+        : undefined
 
     const isPublished = !homework.isDeferred
     const changedTaskPublicationDates = homework.tasks!
         .filter(t => t.publicationDate != null)
         .map(t => new Date(t.publicationDate!))
-
-    const publicationDate = homework.publicationDateNotSet
-        ? undefined
-        : new Date(homework.publicationDate!)
 
     const [metadata, setMetadata] = useState<IEditHomeworkState>({
         publicationDate: publicationDate,

--- a/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
+++ b/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
@@ -60,17 +60,16 @@ const CourseHomeworkEditor: FC<{
     const homeworkId = homework.id!
     const courseId = homework.courseId!
 
+    const deadlineDate = homework.deadlineDate ? new Date(homework.deadlineDate) : undefined
+
     const isPublished = !homework.isDeferred
-    const deadline = homework.deadlineDate == null
-        ? undefined
-        : new Date(homework.deadlineDate)
     const changedTaskPublicationDates = homework.tasks!
         .filter(t => t.publicationDate != null)
         .map(t => new Date(t.publicationDate!))
 
     const [metadata, setMetadata] = useState<IEditHomeworkState>({
         hasDeadline: homework.hasDeadline!,
-        deadlineDate: deadline,
+        deadlineDate: deadlineDate,
         isDeadlineStrict: homework.isDeadlineStrict!,
         publicationDate: new Date(homework.publicationDate!),
     })

--- a/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
+++ b/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
@@ -25,10 +25,10 @@ export interface HomeworkAndFilesInfo {
 }
 
 interface IEditHomeworkState {
+    publicationDate?: Date;
     hasDeadline: boolean;
-    deadlineDate: Date | undefined;
+    deadlineDate?: Date;
     isDeadlineStrict: boolean;
-    publicationDate: Date;
 }
 
 interface IEditFilesState {
@@ -67,11 +67,15 @@ const CourseHomeworkEditor: FC<{
         .filter(t => t.publicationDate != null)
         .map(t => new Date(t.publicationDate!))
 
+    const publicationDate = homework.publicationDateNotSet
+        ? undefined
+        : new Date(homework.publicationDate!)
+
     const [metadata, setMetadata] = useState<IEditHomeworkState>({
+        publicationDate: publicationDate,
         hasDeadline: homework.hasDeadline!,
         deadlineDate: deadlineDate,
         isDeadlineStrict: homework.isDeadlineStrict!,
-        publicationDate: new Date(homework.publicationDate!),
     })
     const [title, setTitle] = useState<string>(homework.title!)
     const [tags, setTags] = useState<string[]>(homework.tags!)
@@ -158,7 +162,7 @@ const CourseHomeworkEditor: FC<{
         }
     }
 
-    const isSomeTaskSoonerThanHomework = changedTaskPublicationDates.some(d => d < metadata.publicationDate)
+    const isSomeTaskSoonerThanHomework = changedTaskPublicationDates.some(d => d < metadata.publicationDate!)
     const isDisabled = isSomeTaskSoonerThanHomework || hasErrors || !isLoaded
 
     return (

--- a/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
+++ b/hwproj.front/src/components/Homeworks/CourseHomeworkExperimental.tsx
@@ -270,6 +270,8 @@ const CourseHomeworkEditor: FC<{
 const CourseHomeworkExperimental: FC<{
     homeworkAndFilesInfo: HomeworkAndFilesInfo,
     isMentor: boolean,
+    initialEditMode: boolean,
+    onMount: () => void,
     onUpdate: (x: { homework: HomeworkViewModel, fileInfos: FileInfoDTO[] } & { isDeleted?: boolean }) => void
 }> = (props) => {
     const {homework, filesInfo} = props.homeworkAndFilesInfo
@@ -279,7 +281,8 @@ const CourseHomeworkExperimental: FC<{
     const [editMode, setEditMode] = useState(false)
 
     useEffect(() => {
-        setEditMode(false)
+        setEditMode(props.initialEditMode)
+        props.onMount()
     }, [homework.id])
 
     if (editMode) return <CourseHomeworkEditor

--- a/hwproj.front/src/components/Homeworks/EditHomework.tsx
+++ b/hwproj.front/src/components/Homeworks/EditHomework.tsx
@@ -92,9 +92,9 @@ const EditHomework: FC = () => {
             ? undefined
             : new Date(homework.publicationDate!)
 
-        const deadlineDate = homework.deadlineDate
-            ? new Date(homework.deadlineDate)
-            : undefined
+        const deadlineDate = homework.deadlineDateNotSet
+            ? undefined
+            : new Date(homework.deadlineDate!)
 
         setEditHomework((prevState) => ({
             ...prevState,

--- a/hwproj.front/src/components/Homeworks/EditHomework.tsx
+++ b/hwproj.front/src/components/Homeworks/EditHomework.tsx
@@ -26,9 +26,9 @@ interface IEditHomeworkState {
     courseMentorIds: string[];
     edited: boolean;
     hasDeadline: boolean;
-    deadlineDate: Date | undefined;
+    deadlineDate?: Date;
     isDeadlineStrict: boolean;
-    publicationDate: Date;
+    publicationDate?: Date;
     isPublished: boolean;
     isGroupWork: boolean;
     hasErrors: boolean;
@@ -67,7 +67,6 @@ const EditHomework: FC = () => {
         hasDeadline: false,
         deadlineDate: undefined,
         isDeadlineStrict: false,
-        publicationDate: new Date(),
         isPublished: false,
         hasErrors: false,
         tags: [],
@@ -90,6 +89,10 @@ const EditHomework: FC = () => {
         const course = await ApiSingleton.coursesApi.coursesGetCourseData(homework.courseId!)
         const deadline = homework.deadlineDate ? new Date(homework.deadlineDate) : undefined
 
+        const publicationDate = homework.publicationDateNotSet
+            ? undefined
+            : new Date(homework.publicationDate!)
+
         setEditHomework((prevState) => ({
             ...prevState,
             isLoaded: true,
@@ -101,7 +104,7 @@ const EditHomework: FC = () => {
             hasDeadline: homework.hasDeadline!,
             deadlineDate: deadline,
             isDeadlineStrict: homework.isDeadlineStrict!,
-            publicationDate: new Date(homework.publicationDate!),
+            publicationDate: publicationDate,
             isPublished: !homework.isDeferred,
             hasErrors: false,
             tags: homework.tags!,
@@ -179,7 +182,7 @@ const EditHomework: FC = () => {
     const classes = useStyles()
 
     const isSomeTaskSoonerThanHomework = editHomework.changedTaskPublicationDates
-        .some(d => d < editHomework.publicationDate)
+        .some(d => d < editHomework.publicationDate!)
 
     if (editHomework.edited) {
         return <Navigate to={`/courses/${editHomework.courseId}/editHomeworks`}/>;

--- a/hwproj.front/src/components/Homeworks/EditHomework.tsx
+++ b/hwproj.front/src/components/Homeworks/EditHomework.tsx
@@ -88,9 +88,7 @@ const EditHomework: FC = () => {
     const getHomework = async () => {
         const homework = await ApiSingleton.homeworksApi.homeworksGetForEditingHomework(+homeworkId!)
         const course = await ApiSingleton.coursesApi.coursesGetCourseData(homework.courseId!)
-        const deadline = homework.deadlineDate == null
-            ? undefined
-            : new Date(homework.deadlineDate)
+        const deadline = homework.deadlineDate ? new Date(homework.deadlineDate) : undefined
 
         setEditHomework((prevState) => ({
             ...prevState,

--- a/hwproj.front/src/components/Homeworks/EditHomework.tsx
+++ b/hwproj.front/src/components/Homeworks/EditHomework.tsx
@@ -87,11 +87,14 @@ const EditHomework: FC = () => {
     const getHomework = async () => {
         const homework = await ApiSingleton.homeworksApi.homeworksGetForEditingHomework(+homeworkId!)
         const course = await ApiSingleton.coursesApi.coursesGetCourseData(homework.courseId!)
-        const deadline = homework.deadlineDate ? new Date(homework.deadlineDate) : undefined
 
         const publicationDate = homework.publicationDateNotSet
             ? undefined
             : new Date(homework.publicationDate!)
+
+        const deadlineDate = homework.deadlineDate
+            ? new Date(homework.deadlineDate)
+            : undefined
 
         setEditHomework((prevState) => ({
             ...prevState,
@@ -102,7 +105,7 @@ const EditHomework: FC = () => {
             courseId: homework.courseId!,
             courseMentorIds: course.mentors!.map(x => x.userId!),
             hasDeadline: homework.hasDeadline!,
-            deadlineDate: deadline,
+            deadlineDate: deadlineDate,
             isDeadlineStrict: homework.isDeadlineStrict!,
             publicationDate: publicationDate,
             isPublished: !homework.isDeferred,

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -49,6 +49,9 @@ interface IHomeworkState {
 }
 
 const Homework: FC<IHomeworkProps> = (props) => {
+    const publicationDate = new Date(props.homework.publicationDate!)
+    const deadlineDate = new Date(props.homework.deadlineDate!)
+
     const [homeworkState, setHomeworkState] = useState<IHomeworkState>({
         createTask: false,
     })
@@ -73,7 +76,7 @@ const Homework: FC<IHomeworkProps> = (props) => {
 
         props.onUpdateClick()
     }
-    
+
     const getDeleteMessage = (homeworkName: string, filesInfo: IFileInfo[]) => {
         let message = `Вы точно хотите удалить задание "${homeworkName}"?`;
         if (filesInfo.length > 0) {
@@ -86,12 +89,13 @@ const Homework: FC<IHomeworkProps> = (props) => {
         return message;
     };
 
+    const publicationDateIsSet = publicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+
+    const publicationDateString = Utils.renderReadableDate(publicationDate)
+    const deadlineDateString = Utils.renderReadableDate(deadlineDate)
+    const tasksCount = props.homework.tasks!.length
 
     const classes = useStyles()
-
-    const homeworkPublicationDateString = Utils.renderReadableDate(new Date(props.homework.publicationDate!))
-    const homeworkDeadlineDateString = Utils.renderReadableDate(new Date(props.homework.deadlineDate!))
-    const tasksCount = props.homework.tasks!.length
 
     return (
         <div style={{width: '100%'}}>

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -89,7 +89,7 @@ const Homework: FC<IHomeworkProps> = (props) => {
         return message;
     };
 
-    const publicationDateIsSet = publicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+    const publicationDateIsSet = !Utils.isMaxAllowedDate(publicationDate)
 
     const publicationDateString = Utils.renderReadableDate(publicationDate)
     const deadlineDateString = Utils.renderReadableDate(deadlineDate)

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -38,6 +38,7 @@ interface IHomeworkProps {
 
 const useStyles = makeStyles(_ => ({
     tools: {
+        width: "100%",
         display: "flex",
         flexDirection: 'row',
         alignItems: 'center',
@@ -113,14 +114,28 @@ const Homework: FC<IHomeworkProps> = (props) => {
                                     {props.homework.title}
                                 </Typography>
                             </Grid>
-                            {props.forMentor &&
+                            {props.forMentor && publicationDateIsSet &&
                                 <Grid item>
-                                    <Chip label={"🕘 " + homeworkPublicationDateString}/>
+                                    <Chip label={"🕘 " + publicationDateString}/>
                                 </Grid>
                             }
-                            {props.homework.hasDeadline &&
+                            {props.forMentor && !publicationDateIsSet &&
                                 <Grid item>
-                                    <Chip label={"⌛ " + homeworkDeadlineDateString}/>
+                                    <Tooltip arrow title={"Не выставлена дата публикации"}>
+                                        <Chip label={"⚠️"}/>
+                                    </Tooltip>
+                                </Grid>
+                            }
+                            {props.homework.hasDeadline && props.homework.deadlineDate &&
+                                <Grid item>
+                                    <Chip label={"⌛ " + deadlineDateString}/>
+                                </Grid>
+                            }
+                            {props.forMentor && props.homework.hasDeadline && !props.homework.deadlineDate &&
+                                <Grid item>
+                                    <Tooltip arrow title={"Не выставлена дата дедлайна"}>
+                                        <Chip label={"⚠️"}/>
+                                    </Tooltip>
                                 </Grid>
                             }
                             {props.forMentor && props.homework.isDeadlineStrict &&

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -52,6 +52,8 @@ const Homework: FC<IHomeworkProps> = (props) => {
     const publicationDate = new Date(props.homework.publicationDate!)
     const deadlineDate = new Date(props.homework.deadlineDate!)
 
+    const publicationDateIsSet = !props.homework.publicationDateNotSet
+
     const [homeworkState, setHomeworkState] = useState<IHomeworkState>({
         createTask: false,
     })
@@ -88,8 +90,6 @@ const Homework: FC<IHomeworkProps> = (props) => {
 
         return message;
     };
-
-    const publicationDateIsSet = !Utils.isMaxSupportedDate(publicationDate)
 
     const publicationDateString = Utils.renderReadableDate(publicationDate)
     const deadlineDateString = Utils.renderReadableDate(deadlineDate)

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -54,6 +54,7 @@ const Homework: FC<IHomeworkProps> = (props) => {
     const deadlineDate = new Date(props.homework.deadlineDate!)
 
     const publicationDateIsSet = !props.homework.publicationDateNotSet
+    const deadlineDateIsSet = !props.homework.deadlineDateNotSet
 
     const [homeworkState, setHomeworkState] = useState<IHomeworkState>({
         createTask: false,
@@ -126,12 +127,12 @@ const Homework: FC<IHomeworkProps> = (props) => {
                                     </Tooltip>
                                 </Grid>
                             }
-                            {props.homework.hasDeadline && props.homework.deadlineDate &&
+                            {props.homework.hasDeadline && deadlineDateIsSet &&
                                 <Grid item>
                                     <Chip label={"⌛ " + deadlineDateString}/>
                                 </Grid>
                             }
-                            {props.forMentor && props.homework.hasDeadline && !props.homework.deadlineDate &&
+                            {props.forMentor && props.homework.hasDeadline && !deadlineDateIsSet &&
                                 <Grid item>
                                     <Tooltip arrow title={"Не выставлена дата дедлайна"}>
                                         <Chip label={"⚠️"}/>

--- a/hwproj.front/src/components/Homeworks/Homework.tsx
+++ b/hwproj.front/src/components/Homeworks/Homework.tsx
@@ -89,7 +89,7 @@ const Homework: FC<IHomeworkProps> = (props) => {
         return message;
     };
 
-    const publicationDateIsSet = !Utils.isMaxAllowedDate(publicationDate)
+    const publicationDateIsSet = !Utils.isMaxSupportedDate(publicationDate)
 
     const publicationDateString = Utils.renderReadableDate(publicationDate)
     const deadlineDateString = Utils.renderReadableDate(deadlineDate)

--- a/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
+++ b/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
@@ -86,7 +86,7 @@ const CourseTaskEditor: FC<{
 
     const isDisabled = hasErrors || !isLoaded
 
-    const homeworkPublicationDateIsSet = !Utils.isMaxAllowedDate(new Date(homework.publicationDate!))
+    const homeworkPublicationDateIsSet = !Utils.isMaxSupportedDate(new Date(homework.publicationDate!))
 
     return (
         <CardContent>

--- a/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
+++ b/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
@@ -45,13 +45,13 @@ const CourseTaskEditor: FC<{
                 })
                 setMetadata({
                     hasDeadline: task.hasDeadline!,
-                    deadlineDate: task.deadlineDate == null
+                    deadlineDate: task.deadlineDateNotSet
                         ? undefined
-                        : new Date(task.deadlineDate),
+                        : new Date(task.deadlineDate!),
                     isDeadlineStrict: task.isDeadlineStrict!,
-                    publicationDate: task.publicationDate == null
+                    publicationDate: task.publicationDateNotSet
                         ? undefined
-                        : new Date(task.publicationDate),
+                        : new Date(task.publicationDate!),
                     isPublished: !task.isDeferred
                 });
             })

--- a/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
+++ b/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
@@ -86,7 +86,7 @@ const CourseTaskEditor: FC<{
 
     const isDisabled = hasErrors || !isLoaded
 
-    const homeworkPublicationDateIsSet = !Utils.isMaxSupportedDate(new Date(homework.publicationDate!))
+    const homeworkPublicationDateIsSet = !homework.publicationDateNotSet
 
     return (
         <CardContent>

--- a/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
+++ b/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
@@ -86,6 +86,8 @@ const CourseTaskEditor: FC<{
 
     const isDisabled = hasErrors || !isLoaded
 
+    const homeworkPublicationDateIsSet = !Utils.isMaxAllowedDate(new Date(homework.publicationDate!))
+
     return (
         <CardContent>
             <Grid container xs={"auto"} spacing={1} direction={"row"} justifyContent={"space-between"}
@@ -134,26 +136,28 @@ const CourseTaskEditor: FC<{
                         }}
                     />
                 </Grid>
-                {metadata && <Grid item xs={12} style={{marginBottom: "15px"}}>
-                    <TaskPublicationAndDeadlineDates
-                        homework={homework}
-                        hasDeadline={metadata.hasDeadline}
-                        isDeadlineStrict={metadata.isDeadlineStrict}
-                        publicationDate={metadata.publicationDate}
-                        deadlineDate={metadata.deadlineDate}
-                        disabledPublicationDate={metadata.isPublished}
-                        onChange={(state) => {
-                            setMetadata({
-                                hasDeadline: state.hasDeadline,
-                                isDeadlineStrict: state.isDeadlineStrict,
-                                publicationDate: state.publicationDate,
-                                deadlineDate: state.deadlineDate,
-                                isPublished: metadata.isPublished, // Остается прежним
-                            })
-                            setHasErrors(state.hasErrors)
-                        }}
-                    />
-                </Grid>}
+                {metadata && homeworkPublicationDateIsSet &&
+                    <Grid item xs={12} style={{marginBottom: "15px"}}>
+                        <TaskPublicationAndDeadlineDates
+                            homework={homework}
+                            hasDeadline={metadata.hasDeadline}
+                            isDeadlineStrict={metadata.isDeadlineStrict}
+                            publicationDate={metadata.publicationDate}
+                            deadlineDate={metadata.deadlineDate}
+                            disabledPublicationDate={metadata.isPublished}
+                            onChange={(state) => {
+                                setMetadata({
+                                    hasDeadline: state.hasDeadline,
+                                    isDeadlineStrict: state.isDeadlineStrict,
+                                    publicationDate: state.publicationDate,
+                                    deadlineDate: state.deadlineDate,
+                                    isPublished: metadata.isPublished, // Остается прежним
+                                })
+                                setHasErrors(state.hasErrors)
+                            }}
+                        />
+                    </Grid>
+                }
             </Grid>
             <CardActions>
                 <LoadingButton

--- a/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
+++ b/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
@@ -1,4 +1,4 @@
-﻿import {CardActions, CardContent, Chip, Divider, Grid, IconButton, TextField, Typography} from "@mui/material";
+import {Alert, CardActions, CardContent, Chip, Divider, Grid, IconButton, TextField, Typography} from "@mui/material";
 import {MarkdownEditor, MarkdownPreview} from "components/Common/MarkdownEditor";
 import {FC, useEffect, useState} from "react"
 import {HomeworkTaskViewModel, HomeworkViewModel} from "../../api";
@@ -6,6 +6,7 @@ import ApiSingleton from "../../api/ApiSingleton";
 import * as React from "react";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+import {Button} from "@material-ui/core";
 import {LoadingButton} from "@mui/lab";
 import TaskPublicationAndDeadlineDates from "../Common/TaskPublicationAndDeadlineDates";
 import DeletionConfirmation from "../DeletionConfirmation";
@@ -21,7 +22,8 @@ interface IEditTaskMetadataState {
 const CourseTaskEditor: FC<{
     speculativeTask: HomeworkTaskViewModel,
     speculativeHomework: HomeworkViewModel,
-    onUpdate: (update: HomeworkTaskViewModel & { isDeleted?: boolean }) => void
+    onUpdate: (update: HomeworkTaskViewModel & { isDeleted?: boolean }) => void,
+    toEditHomework: () => void,
 }> = (props) => {
     const [taskData, setTaskData] = useState<{
         task: HomeworkTaskViewModel,
@@ -158,6 +160,25 @@ const CourseTaskEditor: FC<{
                         />
                     </Grid>
                 }
+                {metadata && !homeworkPublicationDateIsSet &&
+                    <Grid item xs={12} style={{marginBottom: "15px"}}>
+                        <Alert
+                            severity="info"
+                            icon={false}
+                            action={
+                                <Button
+                                    color="inherit"
+                                    size="small"
+                                    onClick={props.toEditHomework}
+                                >
+                                    К заданию
+                                </Button>
+                            }
+                        >
+                            Для изменения дат укажите дату публикации домашнего задания
+                        </Alert>
+                    </Grid>
+                }
             </Grid>
             <CardActions>
                 <LoadingButton
@@ -195,14 +216,18 @@ const CourseTaskExperimental: FC<{
     task: HomeworkTaskViewModel,
     homework: HomeworkViewModel,
     isMentor: boolean,
+    initialEditMode: boolean,
+    onMount: () => void,
     onUpdate: (x: HomeworkTaskViewModel & { isDeleted?: boolean }) => void
+    toEditHomework: () => void,
 }> = (props) => {
     const {task, homework} = props
     const [showEditMode, setShowEditMode] = useState(false)
     const [editMode, setEditMode] = useState(false)
 
     useEffect(() => {
-        setEditMode(false)
+        setEditMode(props.initialEditMode)
+        props.onMount()
     }, [task.id])
 
     if (editMode) {
@@ -213,6 +238,7 @@ const CourseTaskExperimental: FC<{
                 setEditMode(false)
                 props.onUpdate(update)
             }}
+            toEditHomework={props.toEditHomework}
         />
     }
 

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -123,8 +123,7 @@ const EditTask: FC = () => {
             );
         }
 
-        const homeworkPublicationDate = new Date(taskState.homework!.publicationDate!)
-        const homeworkPublicationDateIsSet = !Utils.isMaxSupportedDate(homeworkPublicationDate)
+        const homeworkPublicationDateIsSet = !taskState.homework?.publicationDateNotSet
 
         return (
             <div className="container">

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
-import {Navigate, Link, useParams} from "react-router-dom";
+import {Navigate, Link, useParams, useNavigate} from "react-router-dom";
 import ApiSingleton from "../../api/ApiSingleton";
 import {FC, useEffect, useState} from "react";
 import EditIcon from "@material-ui/icons/Edit";
 import {makeStyles} from "@material-ui/styles";
 import {Button, CircularProgress} from "@material-ui/core";
-import {Typography, TextField, Grid} from "@mui/material";
+import {Typography, TextField, Grid, Alert} from "@mui/material";
 import {MarkdownEditor} from "../Common/MarkdownEditor";
 import TaskPublicationAndDeadlineDates from "../Common/TaskPublicationAndDeadlineDates";
 import {HomeworkViewModel} from "../../api";
-import Utils from "services/Utils";
 
 interface IEditTaskState {
     isLoaded: boolean;
@@ -96,6 +95,11 @@ const EditTask: FC = () => {
             isTaskPublished: !task.isDeferred,
         }))
     }
+
+    const navigate = useNavigate()
+
+    const toEditHomework = () =>
+        navigate(`/homework/${taskState.homeworkId}/edit`)
 
     const handleSubmit = async (e: any) => {
         e.preventDefault();
@@ -226,6 +230,25 @@ const EditTask: FC = () => {
                                                 hasErrors: state.hasErrors
                                             }))}
                                         />
+                                    </Grid>
+                                }
+                                {!homeworkPublicationDateIsSet &&
+                                    <Grid item xs={12} style={{width: "90%", marginBottom: "10px"}}>
+                                        <Alert
+                                            severity="info"
+                                            icon={false}
+                                            action={
+                                                <Button
+                                                    color="inherit"
+                                                    size="small"
+                                                    onClick={toEditHomework}
+                                                >
+                                                    К заданию
+                                                </Button>
+                                            }
+                                        >
+                                            Для изменения дат укажите дату публикации домашнего задания
+                                        </Alert>
                                     </Grid>
                                 }
                                 <Grid item xs={12}>

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -124,7 +124,7 @@ const EditTask: FC = () => {
         }
 
         const homeworkPublicationDate = new Date(taskState.homework!.publicationDate!)
-        const homeworkPublicationDateIsSet = !Utils.isMaxAllowedDate(homeworkPublicationDate)
+        const homeworkPublicationDateIsSet = !Utils.isMaxSupportedDate(homeworkPublicationDate)
 
         return (
             <div className="container">

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -69,13 +69,13 @@ const EditTask: FC = () => {
         const task = taskForEditing.task!
         const course = await ApiSingleton.coursesApi.coursesGetCourseData(homework.courseId!)
 
-        const publicationDate = task.publicationDate
-            ? new Date(task.publicationDate)
-            : undefined
+        const publicationDate = task.publicationDateNotSet
+            ? undefined
+            : new Date(task.publicationDate!)
 
-        const deadlineDate = task.deadlineDate
-            ? new Date(task.deadlineDate)
-            : undefined
+        const deadlineDate = task.deadlineDateNotSet
+            ? undefined
+            : new Date(task.deadlineDate!)
 
         setTaskState((prevState) => ({
             ...prevState,
@@ -127,7 +127,7 @@ const EditTask: FC = () => {
             );
         }
 
-        const homeworkPublicationDateIsSet = !taskState.homework?.publicationDateNotSet
+        const homeworkPublicationDateIsSet = !taskState.homework!.publicationDateNotSet
 
         return (
             <div className="container">

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -124,8 +124,7 @@ const EditTask: FC = () => {
         }
 
         const homeworkPublicationDate = new Date(taskState.homework!.publicationDate!)
-        const homeworkPublicationDateIsSet =
-            homeworkPublicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+        const homeworkPublicationDateIsSet = !Utils.isMaxAllowedDate(homeworkPublicationDate)
 
         return (
             <div className="container">

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -213,7 +213,7 @@ const EditTask: FC = () => {
                                     />
                                 </Grid>
                                 {homeworkPublicationDateIsSet &&
-                                    <Grid item style={{width: "90%", marginBottom: "10px"}}>
+                                    <Grid item xs={12} style={{width: "90%", marginBottom: "10px"}}>
                                         <TaskPublicationAndDeadlineDates
                                             homework={taskState.homework!}
                                             hasDeadline={taskState.hasDeadline}

--- a/hwproj.front/src/components/Tasks/EditTask.tsx
+++ b/hwproj.front/src/components/Tasks/EditTask.tsx
@@ -9,6 +9,7 @@ import {Typography, TextField, Grid} from "@mui/material";
 import {MarkdownEditor} from "../Common/MarkdownEditor";
 import TaskPublicationAndDeadlineDates from "../Common/TaskPublicationAndDeadlineDates";
 import {HomeworkViewModel} from "../../api";
+import Utils from "services/Utils";
 
 interface IEditTaskState {
     isLoaded: boolean;
@@ -69,13 +70,13 @@ const EditTask: FC = () => {
         const task = taskForEditing.task!
         const course = await ApiSingleton.coursesApi.coursesGetCourseData(homework.courseId!)
 
-        const publication = task.publicationDate == null
-            ? undefined
-            : new Date(task.publicationDate)
+        const publicationDate = task.publicationDate
+            ? new Date(task.publicationDate)
+            : undefined
 
-        const deadline = task.deadlineDate == null
-            ? undefined
-            : new Date(task.deadlineDate)
+        const deadlineDate = task.deadlineDate
+            ? new Date(task.deadlineDate)
+            : undefined
 
         setTaskState((prevState) => ({
             ...prevState,
@@ -85,9 +86,9 @@ const EditTask: FC = () => {
             maxRating: task.maxRating!,
             courseId: homework.courseId!,
             hasDeadline: task.hasDeadline!,
-            deadlineDate: deadline,
+            deadlineDate: deadlineDate,
             isDeadlineStrict: task.isDeadlineStrict!,
-            publicationDate: publication,
+            publicationDate: publicationDate,
             homeworkId: task.homeworkId!,
             courseMentorIds: course.mentors!.map(x => x.userId!),
             homework: homework,
@@ -121,6 +122,11 @@ const EditTask: FC = () => {
                 </Typography>
             );
         }
+
+        const homeworkPublicationDate = new Date(taskState.homework!.publicationDate!)
+        const homeworkPublicationDateIsSet =
+            homeworkPublicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+
         return (
             <div className="container">
                 <Grid container xs={12} justifyContent="center">
@@ -204,24 +210,26 @@ const EditTask: FC = () => {
                                         }}
                                     />
                                 </Grid>
-                                <Grid item style={{width: "90%", marginBottom: "10px"}}>
-                                    <TaskPublicationAndDeadlineDates
-                                        homework={taskState.homework!}
-                                        hasDeadline={taskState.hasDeadline}
-                                        isDeadlineStrict={taskState.isDeadlineStrict}
-                                        publicationDate={taskState.publicationDate}
-                                        deadlineDate={taskState.deadlineDate}
-                                        disabledPublicationDate={taskState.isTaskPublished}
-                                        onChange={(state) => setTaskState(prevState => ({
-                                            ...prevState,
-                                            hasDeadline: state.hasDeadline,
-                                            isDeadlineStrict: state.isDeadlineStrict,
-                                            publicationDate: state.publicationDate,
-                                            deadlineDate: state.deadlineDate,
-                                            hasErrors: state.hasErrors
-                                        }))}
-                                    />
-                                </Grid>
+                                {homeworkPublicationDateIsSet &&
+                                    <Grid item style={{width: "90%", marginBottom: "10px"}}>
+                                        <TaskPublicationAndDeadlineDates
+                                            homework={taskState.homework!}
+                                            hasDeadline={taskState.hasDeadline}
+                                            isDeadlineStrict={taskState.isDeadlineStrict}
+                                            publicationDate={taskState.publicationDate}
+                                            deadlineDate={taskState.deadlineDate}
+                                            disabledPublicationDate={taskState.isTaskPublished}
+                                            onChange={(state) => setTaskState(prevState => ({
+                                                ...prevState,
+                                                hasDeadline: state.hasDeadline,
+                                                isDeadlineStrict: state.isDeadlineStrict,
+                                                publicationDate: state.publicationDate,
+                                                deadlineDate: state.deadlineDate,
+                                                hasErrors: state.hasErrors
+                                            }))}
+                                        />
+                                    </Grid>
+                                }
                                 <Grid item xs={12}>
                                     <Button
                                         fullWidth

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -59,7 +59,7 @@ const Task: FC<ITaskProp> = (props) => {
 
     const {task} = props
 
-    const publicationDateIsSet = publicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+    const publicationDateIsSet = !Utils.isMaxAllowedDate(publicationDate)
 
     const publicationDateString = Utils.renderReadableDate(publicationDate)
     const deadlineDateString = Utils.renderReadableDate(deadlineDate)

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -33,16 +33,14 @@ const useStyles = makeStyles(theme => ({
         flexDirection: 'row',
         alignItems: 'center',
     },
-    tool: {
-        marginRight: theme.spacing(2),
-        marginLeft: theme.spacing(2),
-    },
     text: {
         marginTop: '16px',
     }
 }))
 
 const Task: FC<ITaskProp> = (props) => {
+    const publicationDate = new Date(props.task.publicationDate!)
+    const deadlineDate = new Date(props.task.deadlineDate!)
 
     const [isOpenDialogDeleteTask, setIsOpenDialogDeleteTask] = useState<boolean>(false)
 
@@ -61,10 +59,13 @@ const Task: FC<ITaskProp> = (props) => {
 
     const {task} = props
 
-    const publicationDate = Utils.renderReadableDate(new Date(task.publicationDate!))
-    const deadlineDate = Utils.renderReadableDate(new Date(task.deadlineDate!))
+    const publicationDateIsSet = publicationDate.getTime() !== Utils.maxAllowedDate.getTime()
+
+    const publicationDateString = Utils.renderReadableDate(publicationDate)
+    const deadlineDateString = Utils.renderReadableDate(deadlineDate)
 
     const classes = useStyles()
+
     return (
         <div style={{width: '100%'}}>
             <Accordion expanded={props.isExpanded ? true : undefined}>
@@ -129,7 +130,7 @@ const Task: FC<ITaskProp> = (props) => {
                                     </RouterLink>
                                 </Grid>
                             }
-                        </Grid>
+                        </Stack>
                     </div>
                 </AccordionSummary>
                 <AccordionDetails>

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -29,6 +29,7 @@ interface ITaskProp {
 
 const useStyles = makeStyles(theme => ({
     tools: {
+        width: "100%",
         display: "flex",
         flexDirection: 'row',
         alignItems: 'center',
@@ -98,12 +99,14 @@ const Task: FC<ITaskProp> = (props) => {
                             {task.isGroupWork &&
                                 <Grid item>
                                     <Chip variant="outlined" color="info" label="Командное"/>
-                                </Grid>}
-                            {props.forMentor &&
+                                </Grid>
+                            }
+                            {props.forMentor && publicationDateIsSet &&
                                 <Grid item>
-                                    <Chip variant="outlined" label={"🕘 " + publicationDate}/>
-                                </Grid>}
-                            {task.hasDeadline &&
+                                    <Chip variant="outlined" label={"🕘 " + publicationDateString}/>
+                                </Grid>
+                            }
+                            {task.hasDeadline && task.deadlineDate &&
                                 <Grid item>
                                     <Tooltip 
                                         arrow
@@ -111,15 +114,23 @@ const Task: FC<ITaskProp> = (props) => {
                                     >
                                         <Chip
                                             variant="outlined"
-                                            label={(task.isDeadlineStrict ? "⛔ До" : "До") + " " + deadlineDate}
+                                            label={(task.isDeadlineStrict ? "⛔ До" : "До") + " " + deadlineDateString}
                                         />
+                                    </Tooltip>
+                                </Grid>
+                            }
+                            {props.forMentor && publicationDateIsSet && task.hasDeadline && !task.deadlineDate &&
+                                <Grid item>
+                                    <Tooltip arrow title={"Не выставлена дата дедлайна"}>
+                                        <Chip label={"⚠️"} variant="outlined"/>
                                     </Tooltip>
                                 </Grid>
                             }
                             {!task.hasDeadline &&
                                 <Grid item>
                                     <Chip variant="outlined" label="без дедлайна"/>
-                                </Grid>}
+                                </Grid>
+                            }
                             {props.forMentor && !props.isReadingMode &&
                                 <Grid item>
                                     <IconButton aria-label="Delete" onClick={openDialogDeleteTask}>
@@ -130,7 +141,7 @@ const Task: FC<ITaskProp> = (props) => {
                                     </RouterLink>
                                 </Grid>
                             }
-                        </Stack>
+                        </Grid>
                     </div>
                 </AccordionSummary>
                 <AccordionDetails>

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -59,7 +59,7 @@ const Task: FC<ITaskProp> = (props) => {
 
     const {task} = props
 
-    const publicationDateIsSet = !Utils.isMaxAllowedDate(publicationDate)
+    const publicationDateIsSet = !Utils.isMaxSupportedDate(publicationDate)
 
     const publicationDateString = Utils.renderReadableDate(publicationDate)
     const deadlineDateString = Utils.renderReadableDate(deadlineDate)

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -44,6 +44,7 @@ const Task: FC<ITaskProp> = (props) => {
     const deadlineDate = new Date(props.task.deadlineDate!)
 
     const publicationDateIsSet = !props.task.publicationDateNotSet
+    const deadlineDateIsSet = !props.task.deadlineDateNotSet
 
     const [isOpenDialogDeleteTask, setIsOpenDialogDeleteTask] = useState<boolean>(false)
 
@@ -106,7 +107,14 @@ const Task: FC<ITaskProp> = (props) => {
                                     <Chip variant="outlined" label={"🕘 " + publicationDateString}/>
                                 </Grid>
                             }
-                            {task.hasDeadline && task.deadlineDate &&
+                            {props.forMentor && !publicationDateIsSet &&
+                                <Grid item>
+                                    <Tooltip arrow title={"Не выставлена дата публикации"}>
+                                        <Chip label={"⚠️"} variant="outlined"/>
+                                    </Tooltip>
+                                </Grid>
+                            }
+                            {task.hasDeadline && deadlineDateIsSet &&
                                 <Grid item>
                                     <Tooltip 
                                         arrow
@@ -119,7 +127,7 @@ const Task: FC<ITaskProp> = (props) => {
                                     </Tooltip>
                                 </Grid>
                             }
-                            {props.forMentor && publicationDateIsSet && task.hasDeadline && !task.deadlineDate &&
+                            {props.forMentor && task.hasDeadline && !deadlineDateIsSet &&
                                 <Grid item>
                                     <Tooltip arrow title={"Не выставлена дата дедлайна"}>
                                         <Chip label={"⚠️"} variant="outlined"/>

--- a/hwproj.front/src/components/Tasks/Task.tsx
+++ b/hwproj.front/src/components/Tasks/Task.tsx
@@ -42,6 +42,8 @@ const Task: FC<ITaskProp> = (props) => {
     const publicationDate = new Date(props.task.publicationDate!)
     const deadlineDate = new Date(props.task.deadlineDate!)
 
+    const publicationDateIsSet = !props.task.publicationDateNotSet
+
     const [isOpenDialogDeleteTask, setIsOpenDialogDeleteTask] = useState<boolean>(false)
 
     const openDialogDeleteTask = () => {
@@ -58,8 +60,6 @@ const Task: FC<ITaskProp> = (props) => {
     }
 
     const {task} = props
-
-    const publicationDateIsSet = !Utils.isMaxSupportedDate(publicationDate)
 
     const publicationDateString = Utils.renderReadableDate(publicationDate)
     const deadlineDateString = Utils.renderReadableDate(deadlineDate)

--- a/hwproj.front/src/services/Utils.ts
+++ b/hwproj.front/src/services/Utils.ts
@@ -1,8 +1,4 @@
 export default class Utils {
-    static get maxAllowedDate() {
-        return new Date("9999-12-31T23:59:59.9999999Z")
-    }
-
     static convertLocalDateToUTCDate(d: Date) {
         let date = new Date(d)
         return new Date(date.getTime() + date.getTimezoneOffset() * 60 * 1000)
@@ -97,5 +93,10 @@ export default class Utils {
         };
 
         return (new Date(date)).toLocaleString(undefined, options)
+    }
+
+    static isMaxAllowedDate(date: Date) {
+        const maxDate = new Date("9999-12-31T23:59:59.9999999Z")
+        return date.getTime() === maxDate.getTime()
     }
 }

--- a/hwproj.front/src/services/Utils.ts
+++ b/hwproj.front/src/services/Utils.ts
@@ -95,7 +95,7 @@ export default class Utils {
         return (new Date(date)).toLocaleString(undefined, options)
     }
 
-    static isMaxAllowedDate(date: Date) {
+    static isMaxSupportedDate(date: Date) {
         const maxDate = new Date("9999-12-31T23:59:59.9999999Z")
         return date.getTime() === maxDate.getTime()
     }

--- a/hwproj.front/src/services/Utils.ts
+++ b/hwproj.front/src/services/Utils.ts
@@ -1,4 +1,8 @@
 export default class Utils {
+    static get maxAllowedDate() {
+        return new Date("9999-12-31T23:59:59.9999999Z")
+    }
+
     static convertLocalDateToUTCDate(d: Date) {
         let date = new Date(d)
         return new Date(date.getTime() + date.getTimezoneOffset() * 60 * 1000)

--- a/hwproj.front/src/services/Utils.ts
+++ b/hwproj.front/src/services/Utils.ts
@@ -94,9 +94,4 @@ export default class Utils {
 
         return (new Date(date)).toLocaleString(undefined, options)
     }
-
-    static isMaxSupportedDate(date: Date) {
-        const maxDate = new Date("9999-12-31T23:59:59.9999999Z")
-        return date.getTime() === maxDate.getTime()
-    }
 }


### PR DESCRIPTION
## Создание курса

Реализовано создание курса на основе существующего в виде отдельного шага создания курса. Лектор может выбрать один из своих курсов с помощью select'а:

<img src="https://github.com/user-attachments/assets/dcdb4ac1-e7ef-4c94-9049-0424860cc84e" width=70%>

Шаг выбора шаблона отмечается непройденным при пропуске:

<img src="https://github.com/user-attachments/assets/c6f9d6f0-1af0-4fa9-af4d-a93bb7755e1d" width=70%>

При выборе шаблона заполняются поля с данными курса:

<img src="https://github.com/user-attachments/assets/cda5e9fd-d909-4429-a412-faaac259c599" width=47%>
<img src="https://github.com/user-attachments/assets/72695c9c-9dab-4c8c-8c24-78887baf00e1" width=47%>

Если же у лектора нет курсов (или произошла ошибка при загрузке), данный шаг пропускается:

<img src="https://github.com/user-attachments/assets/f305493f-ad35-4d97-b8a1-e905b335ca24" width=70%>

## Предупреждения о датах

После создания курса на основе шаблона даты публикаций и дедлайнов считаются невыставленными, показываем лектору соответствующие предупреждения:

<img src="https://github.com/user-attachments/assets/930b403c-e14f-45e6-bcd0-fa1a4ee96e0e" width=80%>

При этом учитываем переопределённые в оригинальном курсе даты у задач:

<img src="https://github.com/user-attachments/assets/0b66956d-f6e2-4cda-8c53-231085000d35" width=80%>
<img src="https://github.com/user-attachments/assets/fa2362ab-149b-4b0d-91f5-0f574d3e2194" width=80%>

Не позволяем изменять даты задач, если не выставлена дата публикации домашнего задания:

<img src="https://github.com/user-attachments/assets/25c91b90-28fa-4af2-b0c4-1d8e24a6a020" width=80%>

Аналогичные предупреждения в старом интерфейсе:

<img src="https://github.com/user-attachments/assets/999e7a56-994f-47d9-8984-ae12a5477e54" width="60%">
<img src="https://github.com/user-attachments/assets/32dd160d-6702-4208-9bdb-6d642b83f282" width="60%">
<img src="https://github.com/user-attachments/assets/f0e12eec-550d-4381-a5b6-85e9f478fabf" width="60%">

Даты при редактировании адекватно отображаются:

<img src="https://github.com/user-attachments/assets/15fe2909-4e6a-4cfa-be6b-39e8ae969e1d" width=47%>
<img src="https://github.com/user-attachments/assets/23efccd0-a189-40ed-a640-ccc1a808ecca" width=47%>
