### PR TITLE
Сортировка заданий по дате публикации

### DIFF
--- a/HwProj.CoursesService/HwProj.CoursesService.API/HwProj.CoursesService.API.csproj
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/HwProj.CoursesService.API.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.3" />

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Repositories/CoursesRepository.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Repositories/CoursesRepository.cs
@@ -15,12 +15,16 @@ namespace HwProj.CoursesService.API.Repositories
 
         public async Task<Course?> GetWithCourseMatesAndHomeworksAsync(long id)
         {
-            return await Context.Set<Course>()
+            var course = await Context.Set<Course>()
                 .Include(c => c.CourseMates)
                 .Include(c => c.Homeworks)
                 .ThenInclude(c => c.Tasks)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.Id == id);
+            
+            // todo: перенести OrderBy в Include после обновления до EF Core 5.x
+            course.Homeworks = course.Homeworks.OrderBy(h => h.PublicationDate).ToList();
+            return course;
         }
 
         public IQueryable<Course> GetAllWithCourseMatesAndHomeworks()

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -185,6 +185,7 @@ namespace HwProj.CoursesService.API.Services
                 .Include(c => c.CourseMates)
                 .Include(c => c.Homeworks).ThenInclude(t => t.Tasks)
                 .ToArrayAsync();
+
             CourseDomain.FillTasksInCourses(coursesWithValues);
 
             var result = await _courseFilterService.ApplyFiltersToCourses(

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -49,18 +49,7 @@ namespace HwProj.CoursesService.API.Services
         public async Task<Course[]> GetAllAsync()
         {
             var courses = await _coursesRepository.GetAllWithCourseMatesAndHomeworks().ToArrayAsync();
-            
-            // todo: перенести сортировку домашних работ на уровень репозитория после обновления до EF Core 5.x
-            courses = courses.Select(c =>
-            {
-                c.Homeworks = c.Homeworks
-                    .OrderBy(h => h.PublicationDate)
-                    .ToList();
-                return c;
-            }).ToArray();
-
             CourseDomain.FillTasksInCourses(courses);
-
             return courses;
         }
 
@@ -196,17 +185,6 @@ namespace HwProj.CoursesService.API.Services
                 .Include(c => c.CourseMates)
                 .Include(c => c.Homeworks).ThenInclude(t => t.Tasks)
                 .ToArrayAsync();
-
-            // todo: перенести сортировку домашних работ на уровень репозитория после обновления до EF Core 5.x
-            coursesWithValues = coursesWithValues
-                .Select(c =>
-                {
-                    c.Homeworks = c.Homeworks
-                        .OrderBy(h => h.PublicationDate)
-                        .ToList();
-                    return c;
-                }).ToArray();
-
             CourseDomain.FillTasksInCourses(coursesWithValues);
 
             var result = await _courseFilterService.ApplyFiltersToCourses(

--- a/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Services/CoursesService.cs
@@ -49,6 +49,15 @@ namespace HwProj.CoursesService.API.Services
         public async Task<Course[]> GetAllAsync()
         {
             var courses = await _coursesRepository.GetAllWithCourseMatesAndHomeworks().ToArrayAsync();
+            
+            // todo: перенести сортировку домашних работ на уровень репозитория после обновления до EF Core 5.x
+            courses = courses.Select(c =>
+            {
+                c.Homeworks = c.Homeworks
+                    .OrderBy(h => h.PublicationDate)
+                    .ToList();
+                return c;
+            }).ToArray();
 
             CourseDomain.FillTasksInCourses(courses);
 
@@ -187,6 +196,16 @@ namespace HwProj.CoursesService.API.Services
                 .Include(c => c.CourseMates)
                 .Include(c => c.Homeworks).ThenInclude(t => t.Tasks)
                 .ToArrayAsync();
+
+            // todo: перенести сортировку домашних работ на уровень репозитория после обновления до EF Core 5.x
+            coursesWithValues = coursesWithValues
+                .Select(c =>
+                {
+                    c.Homeworks = c.Homeworks
+                        .OrderBy(h => h.PublicationDate)
+                        .ToList();
+                    return c;
+                }).ToArray();
 
             CourseDomain.FillTasksInCourses(coursesWithValues);
 


### PR DESCRIPTION
Реализовано в соответствии с #503 (и с учетом ограничений Entity Framework Core 2.x).
![image](https://github.com/user-attachments/assets/508af76e-6d1e-4ed7-abe8-162e414b26cf)

![image](https://github.com/user-attachments/assets/41c2aedb-59af-4381-ae79-5e152318e955)

Реализовано отображение по убыванию даты публикации: самое верхнее задание в режиме редактирования имеет самый поздний срок публикации.
В таблице задания располагаются слева направо по убыванию даты публикации.