### PR TITLE
Не отправлять избыточные данные о студентах при запросе курса

### DIFF
--- a/HwProj.CoursesService/HwProj.CoursesService.API/Filters/CourseDataFilterAttribute.cs
+++ b/HwProj.CoursesService/HwProj.CoursesService.API/Filters/CourseDataFilterAttribute.cs
@@ -31,9 +31,8 @@ namespace HwProj.CoursesService.API.Filters
                     courseDto.CourseMates = courseDto.CourseMates
                         .Where(t =>
                         {
-                            if (!t.IsAccepted) return t.StudentId == userId;
                             if (t.StudentId == userId) isCourseStudent = true;
-                            return true;
+                            return t.StudentId == userId;
                         })
                         .ToArray();
 


### PR DESCRIPTION
В рамках задачи #504.
Для любого пользователя, не являющегося преподавателем курса, теперь не отправляем на фронтенд данные о студентах данного курса.
В случае если пользователь --- студент, записанный на курс, для него отправляем информацию только об одном студенте: о себе