### PR TITLE
Поправить валидацию дат в компонентах PublicationAndDeadlineDates

### DIFF
--- a/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
+++ b/hwproj.front/src/components/Common/PublicationAndDeadlineDates.tsx
@@ -59,10 +59,11 @@ const PublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
     const isDeadlineSoonerThanPublication = (publicationDate: Date, deadlineDate: Date | undefined) =>
         deadlineDate != null && deadlineDate < publicationDate;
 
-    const deadlineSoonerThatHomework = isDeadlineSoonerThanPublication(state.publicationDate, state.deadlineDate)
+    const deadlineDateNotSet = state.hasDeadline && !state.deadlineDate
+    const deadlineSoonerThanHomework = isDeadlineSoonerThanPublication(state.publicationDate, state.deadlineDate)
 
     useEffect(() => {
-        const validationResult = isDeadlineSoonerThanPublication(state.publicationDate, state.deadlineDate)
+        const validationResult = deadlineDateNotSet || deadlineSoonerThanHomework
 
         props.onChange({...state, hasErrors: validationResult})
     }, [state])
@@ -152,8 +153,8 @@ const PublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
                             id="datetime-local"
                             label="Дедлайн задания"
                             type="datetime-local"
-                            error={deadlineSoonerThatHomework}
-                            helperText={deadlineSoonerThatHomework
+                            error={deadlineSoonerThanHomework}
+                            helperText={deadlineSoonerThanHomework
                                 ? "Дедлайн задания не может быть раньше даты публикации"
                                 : deadlineChosenAutomatically
                                     ? "На основе дедлайнов предыдущих работ"

--- a/hwproj.front/src/components/Common/TaskPublicationAndDeadlineDates.tsx
+++ b/hwproj.front/src/components/Common/TaskPublicationAndDeadlineDates.tsx
@@ -54,13 +54,14 @@ const TaskPublicationAndDeadlineDates: React.FC<IDateFieldsProps> = (props) => {
         return deadlineDate < (taskPublicationDate || homeworkPublicationDate)
     }
 
+    const deadlineDateNotSet = state.hasDeadline && !state.deadlineDate
     const taskSoonerThanHomework = !!state.publicationDate && isTaskSoonerThanHomework(state.publicationDate)
     const deadlineSoonerThanPublication = (!!state.deadlineDate || !!homeworkDeadlineDate) && isDeadlineSoonerThanPublication(state.publicationDate, state.deadlineDate)
 
     const showDeadlineEdit = hasDeadline == null ? homework.hasDeadline : hasDeadline
 
     useEffect(() => {
-        const validationResult =
+        const validationResult = deadlineDateNotSet ||
             !!state.publicationDate && isTaskSoonerThanHomework(state.publicationDate) ||
             (!!state.deadlineDate || !!homeworkDeadlineDate) && isDeadlineSoonerThanPublication(state.publicationDate, state.deadlineDate)
 


### PR DESCRIPTION
Можем оставить пустым поле с дедлайном, после попытки редактирования всё зависнет

![Screenshot From 2025-04-07 22-38-16](https://github.com/user-attachments/assets/a159458d-a19c-497b-a9e7-508a1939f552)
