### PR TITLE
Интегрироваться с Яндекс.Метрикой

### DIFF
--- a/hwproj.front/package.json
+++ b/hwproj.front/package.json
@@ -86,6 +86,7 @@
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.2",
     "@types/react-router-dom": "^4.3.5",
+    "@types/yandex-metrika-tag": "^2.0.7",
     "prettier": "2.2.1",
     "typescript": "^4.9.5"
   }

--- a/hwproj.front/public/index.html
+++ b/hwproj.front/public/index.html
@@ -24,9 +24,28 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>HwProj</title>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript" >
+      (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+        m[i].l=1*new Date();
+        for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+        k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+      (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+      ym(101061418, "init", {
+        clickmap: true,
+        trackLinks: true,
+        accurateTrackBounce: true
+      });
+    </script>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!-- Yandex.Metrika counter -->
+    <noscript>
+      <div>
+        <img src="https://mc.yandex.ru/watch/101061418" style="position:absolute; left:-9999px;" alt="" />
+      </div>
+    </noscript>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/hwproj.front/src/App.tsx
+++ b/hwproj.front/src/App.tsx
@@ -25,6 +25,7 @@ import ResetPassword from "components/Auth/ResetPassword";
 import PasswordRecovery from "components/Auth/PasswordRecovery";
 import AuthLayout from "./AuthLayout";
 import ExpertAuthLayout from "./components/Experts/AuthLayout";
+import TrackPageChanges from "TrackPageChanges";
 
 // TODO: add flux
 
@@ -102,6 +103,7 @@ class App extends Component<{ navigate: any }, AppState> {
                         isExpert={this.state.isExpert}
                         onLogout={this.logout}
                         contextAction={this.state.appBarContextAction}/>
+                <TrackPageChanges />
                 <Routes>
                     <Route element={<AuthLayout/>}>
                         <Route path="user/edit" element={<EditProfile isExpert={this.state.isExpert}/>}/>

--- a/hwproj.front/src/TrackPageChanges.tsx
+++ b/hwproj.front/src/TrackPageChanges.tsx
@@ -1,0 +1,22 @@
+import ApiSingleton from 'api/ApiSingleton';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const TrackPageChanges = () => {
+    const location = useLocation();
+    
+    useEffect(() => {
+        // Отправляем данные о новом URL в Яндекс.Метрику
+        if (window.ym) {
+            window.ym(101061418, 'hit', location.pathname, {
+                params: {
+                    user_role: ApiSingleton.authService.getRole()
+                }
+            });
+        }
+    }, [location.pathname]);
+
+    return null;
+};
+
+export default TrackPageChanges;

--- a/hwproj.front/src/services/AuthService.ts
+++ b/hwproj.front/src/services/AuthService.ts
@@ -96,6 +96,14 @@ export default class AuthService {
         return this.getProfile()["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
     }
 
+    getRole = () => {
+        if (this.getToken() === null) {
+            return null
+        }
+
+        return  this.getProfile()["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"];
+    }
+    
     isMentor() {
         if (this.getToken() === null) {
             return false


### PR DESCRIPTION
На фронтенде подключена Яндекс.Метрика.

- Реализовано отслеживание перехода по разным "страницам" приложения.
- Реализована передача роли пользователя в виде параметра при отправке статистики посещений сервиса (перехода по разным "страницам").

Используется id тестового счетчика