### PR TITLE
Stats: не показывать группы пользователя без названия

### DIFF
--- a/hwproj.front/src/components/Courses/StudentStats.tsx
+++ b/hwproj.front/src/components/Courses/StudentStats.tsx
@@ -313,6 +313,7 @@ const StudentStats: React.FC<IStudentStatsProps> = (props) => {
                                             <Stack direction="row" spacing={1}>
                                                 <GroupIcon style={{fontSize: "12px"}}/>
                                                 <div>{studentGroups
+                                                    .filter(g => g.name && g.name.trim().length != 0)
                                                     .map(r => r.name)
                                                     .join(', ')}</div>
                                             </Stack>

--- a/hwproj.front/src/components/Courses/StudentStats.tsx
+++ b/hwproj.front/src/components/Courses/StudentStats.tsx
@@ -313,7 +313,7 @@ const StudentStats: React.FC<IStudentStatsProps> = (props) => {
                                             <Stack direction="row" spacing={1}>
                                                 <GroupIcon style={{fontSize: "12px"}}/>
                                                 <div>{studentGroups
-                                                    .filter(g => g.name && g.name.length != 0)
+                                                    .filter(g => g.name?.trim())
                                                     .map(r => r.name)
                                                     .join(', ')}</div>
                                             </Stack>

--- a/hwproj.front/src/components/Courses/StudentStats.tsx
+++ b/hwproj.front/src/components/Courses/StudentStats.tsx
@@ -314,7 +314,7 @@ const StudentStats: React.FC<IStudentStatsProps> = (props) => {
                                                 <GroupIcon style={{fontSize: "12px"}}/>
                                                 <div>{studentGroups
                                                     .filter(g => g.name && g.name.trim().length != 0)
-                                                    .map(r => r.name)
+                                                    .map(r => r.name!.trim())
                                                     .join(', ')}</div>
                                             </Stack>
                                         </Typography>}

--- a/hwproj.front/src/components/Courses/StudentStats.tsx
+++ b/hwproj.front/src/components/Courses/StudentStats.tsx
@@ -313,8 +313,8 @@ const StudentStats: React.FC<IStudentStatsProps> = (props) => {
                                             <Stack direction="row" spacing={1}>
                                                 <GroupIcon style={{fontSize: "12px"}}/>
                                                 <div>{studentGroups
-                                                    .filter(g => g.name && g.name.trim().length != 0)
-                                                    .map(r => r.name!.trim())
+                                                    .filter(g => g.name && g.name.length != 0)
+                                                    .map(r => r.name)
                                                     .join(', ')}</div>
                                             </Stack>
                                         </Typography>}


### PR DESCRIPTION
Была проблема с отображением запятых, если студент состоит в группах без названия:
<img width="366" height="116" alt="image" src="https://github.com/user-attachments/assets/65037eb0-598c-448d-8786-86561b4f32fb" />

Теперь ненужные запятые не отображаются