### PR TITLE
Groups: Убрать указание названий групп при выборе студентов

### DIFF
--- a/hwproj.front/src/components/Common/GroupSelector.tsx
+++ b/hwproj.front/src/components/Common/GroupSelector.tsx
@@ -51,7 +51,7 @@ const GroupSelector: FC<GroupSelectorProps> = (props) => {
 
     const studentToGroups = useMemo(() => {
         const map = new Map<string, string[]>();
-        (props.groups || []).concat(formState).forEach(g => {
+        (groups.filter(g => g.name) || []).concat(formState).forEach(g => {
             g.studentsIds?.forEach(stId => {
                 if (!map.has(stId)) map.set(stId, []);
                 map.get(stId)!.push(g.name!);

--- a/hwproj.front/src/components/Common/GroupSelector.tsx
+++ b/hwproj.front/src/components/Common/GroupSelector.tsx
@@ -51,7 +51,7 @@ const GroupSelector: FC<GroupSelectorProps> = (props) => {
 
     const studentToGroups = useMemo(() => {
         const map = new Map<string, string[]>();
-        (groups.filter(g => g.name) || []).concat(formState).forEach(g => {
+        (props.groups || []).concat(formState).forEach(g => {
             g.studentsIds?.forEach(stId => {
                 if (!map.has(stId)) map.set(stId, []);
                 map.get(stId)!.push(g.name!);
@@ -145,7 +145,7 @@ const GroupSelector: FC<GroupSelectorProps> = (props) => {
                         getOptionLabel={(option) => {
                             const groups = studentToGroups.get(option.userId!);
                             const groupSuffix = groups && groups.length > 0
-                                ? ' — в группе: ' + groups[0]
+                                ? ' — в команде'
                                 : '';
                             return `${option.surname ?? ""} ${option.name ?? ""}  ${option.middleName ?? ""}${groupSuffix}`.trim();
                         }}


### PR DESCRIPTION
Теперь у студентов, состоящих в командах не указывается имя группы, тем самым учитывается случай, когда студент состоит только в студенческих командах

<img width="650" height="129" alt="image" src="https://github.com/user-attachments/assets/ca3c4c35-9767-4a7e-9b1d-09dd0bc9decd" />
