### PR TITLE
Исправить позицию меню добавления критерия

### DIFF
--- a/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
+++ b/hwproj.front/src/components/Tasks/CourseTaskExperimental.tsx
@@ -633,6 +633,7 @@ const CourseTaskEditor: FC<{
                                         sx={{
                                             textTransform: "none",
                                             fontSize: "15px",
+                                            alignSelf: "center",
                                             display: "flex",
                                             alignItems: "center",
                                             gap: "6px",
@@ -640,6 +641,7 @@ const CourseTaskEditor: FC<{
                                             paddingLeft: "0px",
                                             paddingRight: "0px",
                                             minWidth: "auto",
+                                            width: "fit-content",
                                             "&:hover": {
                                                 backgroundColor: "transparent",
                                                 textDecoration: "none"


### PR DESCRIPTION
## Что изменено

  Исправлено отображение меню выбора типа критерия при добавлении критерия оценивания.

  Раньше кнопка «+ Добавить критерий оценивания» визуально была по центру, но фактически занимала всю ширину контейнера.
  Из-за этого меню открывалось у левого края экрана.

  ## Детали

  - Ограничена ширина кнопки до видимой области
  - Кнопка центрируется внутри списка критериев
  - Меню теперь открывается рядом с самой кнопкой